### PR TITLE
feat(backend): add a .env.example and read settings (port/CORS) cleanly

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,9 +5,15 @@ from pydantic import BaseModel
 from pathlib import Path
 from typing import Dict, Literal
 from datetime import datetime
+from dotenv import load_dotenv
 import uuid
 import shutil
 import os
+
+load_dotenv()
+
+allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+port = int(os.getenv("PORT", 8000))
 
 app = FastAPI(title="Mr. TAI Backend", version="0.1.0")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ h11==0.16.0
 idna==3.10
 pydantic==2.11.7
 pydantic_core==2.33.2
+python-dotenv==1.1.1
 python-multipart==0.0.20
 sniffio==1.3.1
 starlette==0.47.2


### PR DESCRIPTION
## Title
<!-- Short, action-oriented title (e.g., "Connect frontend to backend health + upload") -->

## Summary
- What changed:
        Add a .env.example and read settings (port/CORS) cleanly
- Why it changed:
        To prevent backend config from being hardcoded
- Scope (files/subsystems touched):
        main.py
        requirements.txt

## Testing
- [x] Local server runs (`uvicorn main:app --reload`)
- [x] Frontend dev server runs (`npm run dev`)
- [ ] Manual tests performed (describe):
- [ ] Added/updated docs if needed

## Screenshots / Demos (optional)
N/A 

## Checklist
- [x] PR targets the correct branch
- [x] No secrets or large binaries committed
- [ ] CI passes (or explain failures)
- [ ] Linked issues (if any): Closes #

## Next Steps
Basic backend logging + error handler so failures are obvious.
