### PR TITLE
feat(tts): minimal local TTS demo endpoint using pyttsx3

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
-from backend.core.models import Job, JobState  # NEW
-from backend.core.registry import jobs         # NEW
+from backend.core.models import Job, JobState  
+from backend.core.registry import jobs         
+from backend.providers.tts_local import synth_to_wav  
 from fastapi import FastAPI, UploadFile, File, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi import BackgroundTasks
@@ -353,4 +354,13 @@ async def process_upload(
             "device": os.getenv("ASR_DEVICE", "cpu"),
             "compute_type": os.getenv("ASR_COMPUTE_TYPE", "int8"),
         },
+    }
+
+@app.post("/demo/say")
+def demo_say(text: str = "Hello from Mr. TAI!"):
+    demo_out = DATA_DIR / "demo" / "hello.wav"
+    synth_to_wav(text, demo_out)
+    return {
+        "message": "ok",
+        "audio": str(demo_out),
     }

--- a/backend/providers/tts_local.py
+++ b/backend/providers/tts_local.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import pyttsx3
+
+def synth_to_wav(text: str, out_path: Path, rate: int = 200) -> Path:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = pyttsx3.init()
+    # Optional tweaks:
+    engine.setProperty("rate", rate)
+    # engine.setProperty("voice", "com.apple.speech.synthesis.voice.Alex")  # example mac voice
+    engine.save_to_file(text, str(out_path))
+    engine.runAndWait()
+    return out_path

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,3 +44,5 @@ black
 ruff
 pytest
 pre-commit
+
+pyttsx3


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(tts): minimal local TTS demo endpoint using pyttsx3

## Summary
- Fixes Issue #28

## Testing
- Commands run + results
POST http://localhost:8000/demo/say (JSON body optional: {"text":"Test line"})
You should get a path like .../data/demo/hello.wav — play it to confirm.

- Screens / logs
[hello.wav](https://github.com/user-attachments/files/22062520/hello.wav)

## Next Steps
N/A
