### PR TITLE
Feat/commentary minimum

### DIFF
--- a/backend/steps/script.py
+++ b/backend/steps/script.py
@@ -1,0 +1,15 @@
+def segments_to_commentary(segments: list[dict], max_lines: int = 3) -> str:
+    """
+    Heuristic: take the first few non-empty lines, trim, join with pauses.
+    """
+    lines = []
+    for s in segments:
+        t = (s.get("text") or "").strip()
+        if t:
+            lines.append(t)
+        if len(lines) >= max_lines:
+            break
+    if not lines:
+        lines = ["Play starts now.", "Nice move!", "What a finish!"]
+    # add simple pacing cues; pyttsx3 respects punctuation pauses
+    return " ... ".join(lines)


### PR DESCRIPTION
Title: feat|fix|chore(scope): Feat/commentary minimum

## Summary
- Fixes Issue #30 

## Testing
- Commands run + results
Upload a .txt again → /process-upload should return 400 with a clear message.
Upload a small .wav or .mp4:
POST /demo/commentary with the stored_name → returns WAV path under data/demo/..., and no 500s.
- Screens / logs
[commentary_8589e7dc385c49cba39b41eac6b07b13.wav](https://github.com/user-attachments/files/22062629/commentary_8589e7dc385c49cba39b41eac6b07b13.wav)

## Next Steps
N/A
