### PR TITLE
Feat/madden mvp lvl 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ uploads/
 data/
 tmp/
 cache/
+runs/
 
 # Large binaries (keep out of git)
 *.mp4

--- a/prompts/commentary.md
+++ b/prompts/commentary.md
@@ -1,0 +1,10 @@
+# System
+You are a sports play-by-play broadcaster. Keep it under 120 words. Energetic but not cheesy. Avoid clichés. Do not invent teams or details if not provided. If information is missing, keep it generic. End with a short wrap-up sentence.
+
+# User
+Game: {AWAY} vs {HOME}
+Quarter/Clock: {QUARTER} / {CLOCK}
+Score: {AWAY_SCORE}-{HOME_SCORE}
+
+Instruction: Produce one concise, real-time call of the highlight that fits at the start of the clip. Keep total length suitable for ~10–15 seconds of audio. Finish with a one-sentence wrap-up of the impact on the game.
+Tone: {TONE}


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(mvp): Level-1 Madden commentary scaffolding + static serving

## Summary
- Add MVP groundwork for Madden clip → commentary pipeline (no OCR yet).
- Freeze API contract for /analyze_commentate (file in → text/mp3/dubbed.mp4 out).
- Mount /static to serve artifacts from DATA_DIR (uploads/demo/runs) and add to_static_url() helper.
- Add prompt template (prompts/commentary.md) to keep LLM style consistent.
- Create artifact directories: uploads/input, uploads/tts, uploads/dubbed, runs, demo.

## Testing
- Server
uvicorn backend.main:app --reload --port 8000 → server starts, /health returns ok and correct dataDir/uploadDir.
- Static
Drop any file in DATA_DIR/demo/hello.wav; hit /static/demo/hello.wav → 200 OK, plays/downloads.
- Analyze (stub)
curl -X POST http://localhost:8000/analyze_commentate \ -F "file=@clip.mp4" \ -F "home_team=USC" -F "away_team=UCLA" \ -F "score=21-24" -F "quarter=Q4" -F "clock=0:42"
Result: JSON includes text, audio_url (mp3 tone stub), optional video_url (if mux already present), and meta.
- Logs/Screens
Console shows FastAPI startup + request logs.
Opening http://localhost:8000/static/... returns the artifact files.

## Next Steps
- [ ] Replace TTS stub with provider (OpenAI/ElevenLabs/Azure) behind env switches.
- [ ] Hook mux/runlog helpers (see services branch) and return public URLs for artifacts.
