### PR TITLE
fix(deps): add aiofiles for StaticFiles async serving

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -46,3 +46,4 @@ pytest
 pre-commit
 
 pyttsx3
+aiofiles


### PR DESCRIPTION
Title: feat|fix|chore(scope): add aiofiles for StaticFiles async serving

## Summary
- Added aiofiles to backend dependencies to support FastAPI/Starlette StaticFiles mount at /static.
- Without aiofiles, Starlette raises: RuntimeError: package 'aiofiles' is required to use StaticFiles.
- Ensures local dev, CI, and new environments can start the server after introducing static file serving from DATA_DIR.

## Testing
- Install deps
pip install -r requirements.txt (or your env manager)
Verify aiofiles is installed: python -c "import aiofiles; print(aiofiles.__version__)" → prints version, no error.
- Run server
uvicorn backend.main:app --reload --port 8000
Expected: server starts cleanly; no RuntimeError about aiofiles.
- Static check
Place a small file at DATA_DIR/demo/hello.txt
Open http://127.0.0.1:8000/static/demo/hello.txt → 200 OK, contents visible.
- Logs
Startup logs show “Application startup complete.”
Requests to /static/... return 200 (or 404 if file not found), no server errors.

## Next Steps
- [ ] Ensure requirements*.txt (and/or pyproject.toml/Pipfile) include aiofiles consistently (dev & prod).
- [ ] Confirm CI caches are busted/updated so new runners install aiofiles.
- [ ] (Optional) Add a tiny static-file smoke test to CI (hit /static with a seeded artifact).
