### PR TITLE
feat(api): add /analyze_commentate endpoint (text → TTS wav/mp3 → dubbed mp4 + runlog)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -465,3 +465,6 @@ async def demo_commentary(req: CommentaryRequest):
         "audio_url": to_static_url(out_path),
         "segments_used": min(req.max_lines, len(segments)),
     }
+
+from backend.routers.analyze_commentate import router as analyze_router
+app.include_router(analyze_router)

--- a/backend/routers/analyze_commentate.py
+++ b/backend/routers/analyze_commentate.py
@@ -1,0 +1,129 @@
+# backend/routers/analyze_commentate.py
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from pydantic import BaseModel
+from pathlib import Path
+import uuid, time, subprocess, shlex
+
+from backend.services.llm import generate_commentary
+from backend.services.runlog import append_run_log
+from backend.services.mux import mux_audio_video
+
+# pull shared objects from main
+from backend.main import DATA_DIR, UPLOAD_DIR, to_static_url
+from backend.providers.tts_local import synth_to_wav
+
+router = APIRouter()
+
+INPUT_DIR = UPLOAD_DIR / "input"
+TTS_DIR   = UPLOAD_DIR / "tts"
+DUB_DIR   = UPLOAD_DIR / "dubbed"
+for d in (INPUT_DIR, TTS_DIR, DUB_DIR):
+    d.mkdir(parents=True, exist_ok=True)
+
+class AnalyzeOut(BaseModel):
+    id: str
+    text: str
+    audio_url: str | None = None
+    video_url: str | None = None
+    meta: dict
+
+def _safe_ext(name: str, default: str = ".mp4") -> str:
+    s = (name or "").lower()
+    for ext in (".mp4", ".mov", ".mkv", ".webm", ".mpg", ".mpeg"):
+        if s.endswith(ext):
+            return ext
+    return default
+
+def _wav_to_mp3(wav_path: Path) -> Path:
+    mp3_path = wav_path.with_suffix(".mp3")
+    cmd = f'ffmpeg -y -i {shlex.quote(str(wav_path))} -b:a 128k {shlex.quote(str(mp3_path))}'
+    subprocess.run(shlex.split(cmd), check=True)
+    return mp3_path
+
+@router.post("/analyze_commentate", response_model=AnalyzeOut)
+async def analyze_commentate(
+    file: UploadFile = File(...),
+    home_team: str | None = Form(default=None),
+    away_team: str | None = Form(default=None),
+    score: str | None = Form(default=None),     # e.g., "21-24"
+    quarter: str | None = Form(default=None),   # e.g., "Q4"
+    clock: str | None = Form(default=None),     # e.g., "0:42"
+    tone: str = Form(default="play-by-play"),
+    voice: str = Form(default="default"),       # reserved for future provider switch
+):
+    t0 = time.time()
+    run_id = f"run_{uuid.uuid4().hex[:10]}"
+    errors: list[str] = []
+
+    # 1) Save input
+    try:
+        ext = _safe_ext(file.filename or "clip.mp4")
+        in_path = INPUT_DIR / f"{run_id}{ext}"
+        with in_path.open("wb") as f:
+            f.write(await file.read())
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to save input: {e}")
+
+    context = {
+        "home_team": home_team,
+        "away_team": away_team,
+        "score": score,
+        "quarter": quarter,
+        "clock": clock,
+        "tone": tone,
+    }
+
+    # 2) Generate text
+    try:
+        text = generate_commentary(context, tone=tone)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"LLM error: {e}")
+
+    audio_wav = None
+    audio_mp3 = None
+    video_out = None
+
+    # 3) TTS (local wav for now)
+    try:
+        audio_wav = TTS_DIR / f"{run_id}.wav"
+        synth_to_wav(text, audio_wav)
+        # optional: also make an mp3 for convenience on the frontend
+        audio_mp3 = _wav_to_mp3(audio_wav)
+    except Exception as e:
+        errors.append(f"TTS error: {e}")
+
+    # 4) Mux (if we have audio)
+    if audio_wav and audio_wav.exists():
+        try:
+            # mux accepts wav just fine; will encode as AAC
+            video_out = mux_audio_video(str(in_path), str(audio_wav))
+        except Exception as e:
+            errors.append(f"Mux error: {e}")
+
+    # 5) Log
+    elapsed = round(time.time() - t0, 3)
+    append_run_log({
+        "id": run_id,
+        "input_clip": str(in_path),
+        "context": context,
+        "text": text,
+        "audio_wav": str(audio_wav) if audio_wav else None,
+        "audio_mp3": str(audio_mp3) if audio_mp3 else None,
+        "video_path": str(video_out) if video_out else None,
+        "errors": errors or None,
+        "elapsed_s": elapsed,
+    })
+
+    return AnalyzeOut(
+        id=run_id,
+        text=text,
+        audio_url=(to_static_url(audio_mp3) if audio_mp3 and audio_mp3.exists() else
+                   (to_static_url(audio_wav) if audio_wav and audio_wav.exists() else None)),
+        video_url=(to_static_url(video_out) if video_out else None),
+        meta={
+            "usedManualContext": any([home_team, away_team, score, quarter, clock]),
+            "duration_s": elapsed,
+            "provider": {"llm": "stub", "tts": "local_wav"},
+            "errors": errors or None,
+        },
+    )

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -1,0 +1,19 @@
+# backend/services/llm.py
+from textwrap import shorten
+
+def generate_commentary(context: dict, tone: str = "play-by-play") -> str:
+    away = (context.get("away_team") or "the visitors").strip()
+    home = (context.get("home_team") or "the home side").strip()
+    quarter = (context.get("quarter") or "Q?").strip()
+    clock = (context.get("clock") or "?:??").strip()
+    score = (context.get("score") or "—").strip()
+
+    # short, hypey but not cheesy; under ~120 words later enforced by shorten
+    line = (
+        f"{quarter}, {clock} on the clock — {away} against {home}. "
+        f"Here we go! The snap... pressure coming... throws — CAUGHT! "
+        f"Breaking free to the pylon — TOUCHDOWN! "
+        f"Momentum swings and the score stands {score}. "
+        f"{away} just flipped this game on its head."
+    )
+    return shorten(line, width=750, placeholder="…")


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(api): add /analyze_commentate endpoint (text → TTS wav/mp3 → dubbed mp4 + runlog)

## Summary
- Adds POST /analyze_commentate to process a short video clip and return:
commentary text (LLM stub for now),
audio (local TTS to WAV + convenience MP3),
dubbed video (original + commentary audio, AAC, -shortest).
- Saves artifacts under DATA_DIR/uploads/{input,tts,dubbed} and appends a JSONL run log to DATA_DIR/runs/YYYY-MM-DD.jsonl.
- Returns public URLs using the /static mount (served from DATA_DIR).
- Keeps route clean by using small service helpers (llm, mux, runlog).

## Testing
- Pre-reqs
Ensure ffmpeg is installed: brew install ffmpeg
Ensure aiofiles installed (StaticFiles): pip install aiofiles
Backend running:
uvicorn backend.main:app --reload --port 8000
- Smoke test via Swagger
1. Open http://127.0.0.1:8000/docs
2. POST /analyze_commentate → Try It Out
Upload a small clip.mp4
Example fields: home_team=USC, away_team=UCLA, score=21-24, quarter=Q4, clock=0:42, tone=hype
3. Execute → Expect JSON:
text: hype line
audio_url: /static/uploads/tts/run_*.mp3 (or .wav)
video_url: /static/uploads/dubbed/<stem>.dubbed.mp4
- Smoke test via curl
curl -X POST "http://127.0.0.1:8000/analyze_commentate" \
  -F "file=@/path/to/clip.mp4" \
  -F "home_team=USC" -F "away_team=UCLA" \
  -F "score=21-24" -F "quarter=Q4" -F "clock=0:42" \
  -F "tone=hype" -F "voice=default" | jq
- Artifacts created
DATA_DIR/uploads/input/run_*.mp4
DATA_DIR/uploads/tts/run_*.wav and .mp3
DATA_DIR/uploads/dubbed/<stem>.dubbed.mp4
DATA_DIR/runs/<today>.jsonl (one line with ids/paths/errors/elapsed)
- Open URLs
Verify audio/video play in browser: http://127.0.0.1:8000${audio_url|video_url}

## Next Steps
- [ ] Swap LLM stub for real provider (OpenAI/Anthropic) + token limits.
- [ ] Swap local TTS for cloud TTS (OpenAI/ElevenLabs/Azure) via env toggle.
- [ ] Add basic frontend page (upload → analyze → show text/audio/video).
- [ ] Add OCR (optional) for scoreboard extraction; keep manual fields as fallback.
- [ ] Add error telemetry + simple retries around mux/TTS.
- [ ] Record a golden demo run and store under DATA_DIR/demo/ for backups.
