### PR TITLE
feat(health): add /health/env endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -457,3 +457,6 @@ app.include_router(analyze_router)
 
 from backend.routers.demo import router as demo_router
 app.include_router(demo_router)
+
+from backend.routers.health import router as health_router
+app.include_router(health_router)

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,0 +1,39 @@
+# backend/routers/health.py
+from fastapi import APIRouter
+from pathlib import Path
+import os
+
+router = APIRouter()
+
+@router.get("/health/env")
+def env_preview():
+    repo_root = Path(__file__).resolve().parents[2]  # .../Mr.TAI
+    data_dir = Path(os.getenv("DATA_DIR", repo_root / "data"))
+    upload_dir = data_dir / "uploads"
+    demo_dir = data_dir / "demo"
+
+    return {
+        "status": "ok",
+        # server
+        "PORT": int(os.getenv("PORT", "8000")),
+        "DATA_DIR": str(data_dir.resolve()),
+        "UPLOAD_DIR": str(upload_dir.resolve()),
+        "DEMO_DIR": str(demo_dir.resolve()),
+        "ALLOWED_ORIGINS": [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",") if o.strip()],
+        # ASR
+        "ASR": {
+            "model": os.getenv("ASR_MODEL_NAME", "tiny"),
+            "device": os.getenv("ASR_DEVICE", "cpu"),
+            "compute_type": os.getenv("ASR_COMPUTE_TYPE", "int8"),
+        },
+        # LLM/TTS (no secrets)
+        "LLM": {
+            "provider": os.getenv("LLM_PROVIDER", "openai"),
+            "openai_model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            "anthropic_model": os.getenv("ANTHROPIC_MODEL", "claude-sonnet"),
+        },
+        "TTS": {
+            "provider": os.getenv("TTS_PROVIDER", "elevenlabs"),
+            "elevenlabs_voice_id": os.getenv("ELEVENLABS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM"),
+        },
+    }


### PR DESCRIPTION
Title: feat|fix|chore(scope): what changed

## Summary
- Added a new router backend/routers/health.py with GET /health/env
- Returns non-secret config values (PORT, DATA_DIR paths, ALLOWED_ORIGINS, ASR defaults, LLM/TTS providers/models)
- Useful for debugging env setup without exposing API keys

## Testing
- Ran uvicorn backend.main:app --reload
- Called curl http://localhost:8000/health/env → received JSON with correct values
- Confirmed API keys not included

## Next Steps
- [ ]  Add /prewarm endpoint to warm ASR + LLM/TTS models at startup
- [ ] Extend health to include cache/latency stats once those are added
