### PR TITLE
feat(llm): add provider interface with safe stub

### DIFF
--- a/backend/services/llm_providers.py
+++ b/backend/services/llm_providers.py
@@ -1,0 +1,24 @@
+# backend/services/llm_providers.py
+from __future__ import annotations
+from typing import Protocol, Dict, Any
+import os
+
+class LLMClient(Protocol):
+    def generate(self, prompt: str, meta: Dict[str, Any] | None = None) -> str: ...
+
+class StubLLM:
+    """
+    Offline-safe default: returns a short canned line so the rest of
+    the pipeline can run without network/API keys.
+    """
+    def generate(self, prompt: str, meta: Dict[str, Any] | None = None) -> str:
+        tone = (meta or {}).get("tone", "hype")
+        return f"[{tone} demo] Incredible play! The offense strings it together for a highlight moment."
+
+def get_llm() -> LLMClient:
+    """
+    Factory. Real providers will be added next and selected via LLM_PROVIDER.
+    For now, always return StubLLM.
+    """
+    _provider = os.getenv("LLM_PROVIDER", "stub").lower()
+    return StubLLM()


### PR DESCRIPTION
Title: feat|fix|chore(scope): what changed

## Summary
- Introduces backend/services/llm_providers.py with a minimal LLMClient protocol and StubLLM implementation.
- Provides a safe offline default so the pipeline can run without API keys or network calls.
- Adds get_llm() factory (currently returns StubLLM; real providers will be added next).

## Testing
- Import check: python -c "from backend.services.llm_providers import get_llm; print(get_llm().generate('test', {'tone':'hype'}))" → returns short canned line.
- App still boots: uvicorn backend.main:app --reload (no new deps).

## Next Steps
- [ ] Add OpenAI/Anthropic implementations behind the same interface.
- [ ] Switch selection via LLM_PROVIDER env and add to /prewarm.
