### PR TITLE
feat(llm): add OpenAI and Anthropic implementations behind interface

### DIFF
--- a/backend/services/llm_providers.py
+++ b/backend/services/llm_providers.py
@@ -3,22 +3,74 @@ from __future__ import annotations
 from typing import Protocol, Dict, Any
 import os
 
+# ---------- Interface ----------
 class LLMClient(Protocol):
     def generate(self, prompt: str, meta: Dict[str, Any] | None = None) -> str: ...
 
+# ---------- Stub (default/offline) ----------
 class StubLLM:
-    """
-    Offline-safe default: returns a short canned line so the rest of
-    the pipeline can run without network/API keys.
-    """
     def generate(self, prompt: str, meta: Dict[str, Any] | None = None) -> str:
         tone = (meta or {}).get("tone", "hype")
         return f"[{tone} demo] Incredible play! The offense strings it together for a highlight moment."
 
+# ---------- OpenAI ----------
+class OpenAILLM:
+    def __init__(self):
+        from openai import OpenAI
+        key = os.getenv("OPENAI_API_KEY")
+        if not key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        self.client = OpenAI(api_key=key)
+        self.model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        self.temperature = float(os.getenv("LLM_TEMP", "0.8"))
+        self.max_tokens = int(os.getenv("LLM_MAX_TOKENS", "350"))
+
+    def generate(self, prompt: str, meta: Dict[str, Any] | None = None) -> str:
+        sys = "You are an energetic sports commentator. Keep output ~12–18 seconds."
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "system", "content": sys},
+                      {"role": "user", "content": prompt}],
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        return (resp.choices[0].message.content or "").strip()
+
+# ---------- Anthropic ----------
+class AnthropicLLM:
+    def __init__(self):
+        import anthropic
+        key = os.getenv("ANTHROPIC_API_KEY")
+        if not key:
+            raise RuntimeError("ANTHROPIC_API_KEY not set")
+        self.client = anthropic.Anthropic(api_key=key)
+        self.model = os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet-latest")
+        self.temperature = float(os.getenv("LLM_TEMP", "0.8"))
+        self.max_tokens = int(os.getenv("LLM_MAX_TOKENS", "350"))
+
+    def generate(self, prompt: str, meta: Dict[str, Any] | None = None) -> str:
+        msg = self.client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        # concat text blocks only
+        parts = []
+        for b in getattr(msg, "content", []) or []:
+            if getattr(b, "type", "") == "text":
+                parts.append(b.text)
+        return "".join(parts).strip()
+
+# ---------- Factory ----------
 def get_llm() -> LLMClient:
-    """
-    Factory. Real providers will be added next and selected via LLM_PROVIDER.
-    For now, always return StubLLM.
-    """
-    _provider = os.getenv("LLM_PROVIDER", "stub").lower()
-    return StubLLM()
+    provider = os.getenv("LLM_PROVIDER", "stub").lower()
+    try:
+        if provider == "openai":
+            return OpenAILLM()
+        if provider == "anthropic":
+            return AnthropicLLM()
+        return StubLLM()
+    except Exception:
+        # Fallback hard to stub if misconfigured keys/models
+        return StubLLM()


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(llm): add OpenAI and Anthropic implementations behind interface

## Summary
- Implemented OpenAILLM and AnthropicLLM classes in llm_providers.py.
- Selection via LLM_PROVIDER env (stub / openai / anthropic).
- Fallback to StubLLM on missing keys or misconfig.
- Added tunables: OPENAI_MODEL, ANTHROPIC_MODEL, LLM_TEMP, LLM_MAX_TOKENS.

## Testing
- With .env.local containing a valid OPENAI_API_KEY and LLM_PROVIDER=openai:
Ran Python snippet → LLM type: OpenAILLM and real generated commentary.
- Verified fallback still works with LLM_PROVIDER=stub.

## Next Steps
- [ ] Wire get_llm() into /analyze_commentate.
- [ ] Add LLM warmup into /prewarm.
