### PR TITLE
feat(prewarm): warm ASR cache and instantiate LLM/TTS providers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -468,3 +468,6 @@ app.include_router(health_router)
 
 from backend.routers.prewarm import router as prewarm_router
 app.include_router(prewarm_router)
+
+from backend.routers.prewarm import router as prewarm_router
+app.include_router(prewarm_router)

--- a/backend/routers/prewarm.py
+++ b/backend/routers/prewarm.py
@@ -1,27 +1,80 @@
 # backend/routers/prewarm.py
 from fastapi import APIRouter
-from backend.main import get_asr_model, ASR_MODEL_NAME, ASR_DEVICE, ASR_COMPUTE_TYPE
+import os, time
+
+# warm ASR via the shared cache in main.py
+from backend.main import get_asr_model
+# provider factories (instantiate only; avoid paid calls)
+from backend.services.llm_providers import get_llm
+from backend.services.tts_providers import get_tts
 
 router = APIRouter()
+
+def _env(name: str, default: str | None = None) -> str | None:
+    val = os.getenv(name, default)
+    return val.strip() if isinstance(val, str) else val
 
 @router.get("/prewarm")
 @router.post("/prewarm")
 def prewarm():
     """
-    Warm up heavy dependencies so the first real request is fast.
-    For now: calls get_asr_model() to populate its cache.
+    Initialize heavy dependencies so the first real request is faster.
+    - ASR: populates the lru_cache() instance via get_asr_model()
+    - LLM/TTS: instantiate providers (no network calls to avoid cost)
     """
+    out = {"ok": True, "timings_ms": {}, "providers": {}}
+
+    # ASR
+    t0 = time.time()
     try:
-        model = get_asr_model()  # cached singleton
-        # trigger a trivial call to ensure weights are loaded
-        _ = model.transcribe("tests/silence.wav") if False else None
-        return {
-            "ok": True,
-            "asr": {
-                "model": ASR_MODEL_NAME,
-                "device": ASR_DEVICE,
-                "compute_type": ASR_COMPUTE_TYPE,
-            },
+        asr = get_asr_model()  # cached singleton
+        out["providers"]["asr"] = {
+            "model": _env("ASR_MODEL_NAME", "tiny"),
+            "device": _env("ASR_DEVICE", "cpu"),
+            "compute_type": _env("ASR_COMPUTE_TYPE", "int8"),
+            "loaded": True,
+            "cls": type(asr).__name__,
         }
     except Exception as e:
-        return {"ok": False, "asr": {"error": str(e)}}
+        out["ok"] = False
+        out.setdefault("errors", []).append(f"ASR: {e}")
+        out["providers"]["asr"] = {"loaded": False, "error": str(e)}
+    out["timings_ms"]["asr"] = int((time.time() - t0) * 1000)
+
+    # LLM
+    t0 = time.time()
+    try:
+        llm = get_llm()  # do not call .generate() to avoid paid tokens
+        out["providers"]["llm"] = {
+            "provider": _env("LLM_PROVIDER", "stub"),
+            "model_openai": _env("OPENAI_MODEL"),
+            "model_anthropic": _env("ANTHROPIC_MODEL"),
+            "loaded": True,
+            "cls": type(llm).__name__,
+        }
+    except Exception as e:
+        out["ok"] = False
+        out.setdefault("errors", []).append(f"LLM: {e}")
+        out["providers"]["llm"] = {"loaded": False, "error": str(e)}
+    out["timings_ms"]["llm"] = int((time.time() - t0) * 1000)
+
+    # TTS
+    t0 = time.time()
+    try:
+        tts = get_tts()  # do not synthesize to avoid paid audio
+        out["providers"]["tts"] = {
+            "provider": _env("TTS_PROVIDER", "elevenlabs"),
+            "voice_elevenlabs": _env("ELEVENLABS_VOICE_ID"),
+            "model_elevenlabs": _env("ELEVENLABS_MODEL"),
+            "model_openai": _env("OPENAI_TTS_MODEL"),
+            "voice_openai": _env("OPENAI_TTS_VOICE"),
+            "loaded": True,
+            "cls": type(tts).__name__,
+        }
+    except Exception as e:
+        out["ok"] = False
+        out.setdefault("errors", []).append(f"TTS: {e}")
+        out["providers"]["tts"] = {"loaded": False, "error": str(e)}
+    out["timings_ms"]["tts"] = int((time.time() - t0) * 1000)
+
+    return out


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(prewarm): warm ASR cache and instantiate LLM/TTS providers

## Summary
- Extends /prewarm to initialize:
ASR via get_asr_model() (populates the shared LRU cache)
LLM via get_llm() (instantiate only, no token generation)
TTS via get_tts() (instantiate only, no synthesis)
- Works with GET or POST for easier manual testing.
- Returns provider class names and safe config hints, plus per-stage timings.

## Testing
- Server start: uvicorn backend.main:app --reload
- Call: curl http://127.0.0.1:8000/prewarm
Expect { ok: true, providers: { asr: {loaded:true}, llm:{loaded:true}, tts:{loaded:true} }, timings_ms: {...} }
- Verified no paid calls occur during warm (LLM/TTS instantiate only).

## Next Steps
- [ ] Optional: add a lightweight “no-op” audio generation toggle for staging that synthesizes 1–2 words to fully hydrate TTS path.
- [ ] Capture warmup durations in run logs or metrics for observability.
