### PR TITLE
feat(analyze): support audio-only generation (skip mux when no clip)

### DIFF
--- a/backend/routers/analyze_commentate.py
+++ b/backend/routers/analyze_commentate.py
@@ -8,7 +8,7 @@ from backend.services.llm_providers import get_llm
 from backend.services.tts_providers import get_tts
 from backend.services.runlog import append_run_log
 from backend.services.mux import mux_audio_video
-from backend.services.tone_profiles import build_llm_prompt, normalize_tone  # <— NEW
+from backend.services.tone_profiles import build_llm_prompt, normalize_tone
 
 # pull shared objects from main
 from backend.main import DATA_DIR, UPLOAD_DIR, to_static_url
@@ -43,7 +43,7 @@ def _wav_to_mp3(wav_path: Path) -> Path:
 
 @router.post("/analyze_commentate", response_model=AnalyzeOut)
 async def analyze_commentate(
-    file: UploadFile = File(...),
+    file: UploadFile | None = File(default=None),       # <-- optional now
     home_team: str | None = Form(default=None),
     away_team: str | None = Form(default=None),
     score: str | None = Form(default=None),
@@ -51,19 +51,26 @@ async def analyze_commentate(
     clock: str | None = Form(default=None),
     tone: str = Form(default="play-by-play"),
     voice: str = Form(default="default"),
+    audio_only: bool = Form(default=False),             # <-- new
 ):
     t0 = time.time()
     run_id = f"run_{uuid.uuid4().hex[:10]}"
     errors: list[str] = []
 
-    # 1) Save input
-    try:
-        ext = _safe_ext(file.filename or "clip.mp4")
-        in_path = INPUT_DIR / f"{run_id}{ext}"
-        with in_path.open("wb") as f:
-            f.write(await file.read())
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Failed to save input: {e}")
+    in_path: Path | None = None
+    if file is not None:
+        # 1) Save input (only when a clip is provided)
+        try:
+            ext = _safe_ext(file.filename or "clip.mp4")
+            in_path = INPUT_DIR / f"{run_id}{ext}"
+            with in_path.open("wb") as f:
+                f.write(await file.read())
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Failed to save input: {e}")
+    else:
+        if not audio_only:
+            # No file and not audio-only → invalid request
+            raise HTTPException(status_code=400, detail="No clip provided and audio_only=false")
 
     context = {
         "home_team": home_team,
@@ -77,7 +84,7 @@ async def analyze_commentate(
     # 2) Generate text via LLM (tone-aware)
     try:
         llm = get_llm()
-        prompt = build_llm_prompt(context)  # tone handled inside
+        prompt = build_llm_prompt(context)
         text = llm.generate(prompt, meta={"tone": normalize_tone(tone)})
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"LLM error: {e}")
@@ -90,15 +97,16 @@ async def analyze_commentate(
     # 3) TTS (provider-based mp3)
     try:
         tts = get_tts()
-        audio_mp3_path = tts.synth_to_file(text, TTS_DIR, tone=tone)  # <— pass tone  # returns MP3 path
+        audio_mp3_path = tts.synth_to_file(text, TTS_DIR, tone=tone)
         audio_mp3 = Path(audio_mp3_path)
     except Exception as e:
         errors.append(f"TTS error: {e}")
         audio_mp3 = None
 
-    # 4) Mux (convert mp3 -> wav if needed, then mux)
-    if audio_mp3 and audio_mp3.exists():
+    # 4) Mux — only if we have a video input and not audio-only
+    if (not audio_only) and in_path and in_path.exists() and audio_mp3 and audio_mp3.exists():
         try:
+            # Convert MP3 → WAV (mono 16k) if mux expects wav
             audio_wav = audio_mp3.with_suffix(".wav")
             cmd = f'ffmpeg -y -i {shlex.quote(str(audio_mp3))} -ac 1 -ar 16000 {shlex.quote(str(audio_wav))}'
             subprocess.run(shlex.split(cmd), check=True)
@@ -112,12 +120,13 @@ async def analyze_commentate(
     elapsed = round(time.time() - t0, 3)
     append_run_log({
         "id": run_id,
-        "input_clip": str(in_path),
+        "input_clip": str(in_path) if in_path else None,
         "context": context,
         "text": text,
         "audio_wav": str(audio_wav) if audio_wav else None,
         "audio_mp3": str(audio_mp3) if audio_mp3 else None,
         "video_path": str(video_out) if video_out else None,
+        "audio_only": audio_only,
         "errors": errors or None,
         "elapsed_s": elapsed,
     })
@@ -127,14 +136,14 @@ async def analyze_commentate(
     return AnalyzeOut(
         id=run_id,
         text=text,
-        audio_url=(to_static_url(audio_mp3) if (audio_mp3 and audio_mp3.exists()) else
-                   (to_static_url(audio_wav) if (audio_wav and audio_wav.exists()) else None)),
+        audio_url=(to_static_url(audio_mp3) if (audio_mp3 and audio_mp3.exists()) else None),
         video_url=(to_static_url(video_out) if video_out else None),
         meta={
             "usedManualContext": any([home_team, away_team, score, quarter, clock]),
             "duration_s": elapsed,
             "provider": {"llm": type(llm).__name__, "tts": tts_name},
             "prompt_tone": normalize_tone(tone),
+            "audio_only": audio_only,
             "errors": errors or None,
         },
     )


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(analyze): support audio-only generation (skip mux when no clip)

## Summary
- Makes file optional and adds audio_only flag to /analyze_commentate.
- When audio_only=true, generate commentary + TTS and skip mux/video.
- Keeps tone-aware LLM + tone-aware TTS behavior.

## Testing
- audio_only=true without a file returns MP3 and video_url=null.
- With a clip and audio_only=false, end-to-end dubbing still works.
- Confirmed meta.audio_only and meta.prompt_tone present.

## Next Steps
- [ ] Frontend: add “Audio only” toggle and guard analyze when no clip unless audio-only.
- [ ] Retry/timeout on TTS + clearer ffmpeg error messages.
