### PR TITLE
feat(ocr): add scoreboard OCR service with safe type hints + fallback

### DIFF
--- a/backend/services/ocr.py
+++ b/backend/services/ocr.py
@@ -5,16 +5,16 @@ from typing import Optional, Dict, TYPE_CHECKING, Any
 import os, re, logging
 from pathlib import Path
 
-# Type-only import so Pylance can see the type without requiring Pillow at runtime
+# Type-only alias so editors get hints without requiring Pillow at runtime
 if TYPE_CHECKING:
-    # import the class type only for type checkers
     from PIL.Image import Image as _PILImageType
     PILImageLike = _PILImageType
 else:
-    # at runtime (or if Pillow missing), treat as Any
     PILImageLike = Any  # type: ignore[assignment]
 
 log = logging.getLogger(__name__)
+
+# --------------------------- Model ---------------------------
 
 @dataclass
 class OCRScoreboard:
@@ -30,15 +30,25 @@ class OCRScoreboard:
     def to_dict(self) -> Dict[str, Optional[str]]:
         return asdict(self)
 
+# --------------------------- Parsing ---------------------------
+
 def _parse_scoreboard_text(text: str) -> OCRScoreboard:
     """
     Heuristics to pull (teams, score, quarter, clock) from OCR text.
+    Also handles cases where the right score is glued to the clock (e.g., '0:4224')
+    and where 'Q4' is misread as ':4'.
     """
     t = (text or "").upper()
 
     # quarter: Q1..Q4 or OT
     q = re.search(r"\b(Q[1-4]|OT)\b", t)
     quarter = q.group(1) if q else None
+
+    # --- NEW: tolerate ':4' / ';3' misreads for 'Q4' / 'Q3'
+    if not quarter:
+        m_colon_q = re.search(r"(^|[^A-Z0-9])[:;]\s*([1-4])\b", t)
+        if m_colon_q:
+            quarter = f"Q{m_colon_q.group(2)}"
 
     # clock: 12:34 or 0:42
     clk = re.search(r"\b([0-5]?\d:[0-5]\d)\b", t)
@@ -48,12 +58,31 @@ def _parse_scoreboard_text(text: str) -> OCRScoreboard:
     sc = re.search(r"\b(\d{1,2})\s*[-:]\s*(\d{1,2})\b", t)
     score = f"{sc.group(1)}-{sc.group(2)}" if sc else None
 
+    # If no explicit score, infer L...MM:SS...R
+    if not score:
+        m = re.search(r"\b(\d{1,2})\D{0,10}([0-5]?\d:[0-5]\d)\D{0,10}(\d{1,2})\b", t)
+        if m:
+            score = f"{m.group(1)}-{m.group(3)}"
+            if not clock:
+                clock = m.group(2)
+        elif clock:
+            # handle glued right score like '0:4224'
+            i = t.find(clock)
+            if i != -1:
+                tail = t[i + len(clock): i + len(clock) + 6]
+                r = re.search(r"\s*[:\-]?\s*(\d{1,2})\b", tail)
+                if r:
+                    head = t[max(0, i - 6): i]
+                    l = re.search(r"(\d{1,2})\b", head)
+                    if l:
+                        score = f"{l.group(1)}-{r.group(1)}"
+
     # crude team extraction: tokens near score
     home_team = away_team = None
-    if sc:
-        i = sc.start()
-        left = t[:i].strip()[-25:]
-        right = t[sc.end():].strip()[:25]
+    anchor = sc.start() if sc else (t.find(score.replace('-', '')) if score else -1)
+    if score and anchor >= 0:
+        left = t[:anchor].strip()[-25:]
+        right = t[anchor + len(score):].strip()[:25]
         left_tokens = re.findall(r"[A-Z]{2,12}", left)
         right_tokens = re.findall(r"[A-Z]{2,12}", right)
         home_team = left_tokens[-1] if left_tokens else None
@@ -69,21 +98,106 @@ def _parse_scoreboard_text(text: str) -> OCRScoreboard:
         used_stub=False,
     )
 
-def _preprocess(img: PILImageLike) -> PILImageLike:
+# --------------------------- OCR helpers ---------------------------
+
+def _ocr_text(img: Any, config: str) -> str:
+    """Run Tesseract with given config; returns trimmed text (or empty on failure)."""
+    try:
+        import pytesseract  # type: ignore
+        txt = pytesseract.image_to_string(img, lang="eng", config=config) or ""
+        return txt.strip()
+    except Exception:
+        return ""
+
+def _cv_red_mask(img_pil: PILImageLike) -> Optional[PILImageLike]:
     """
-    Lightweight preprocessing for OCR: grayscale -> autocontrast -> sharpen.
-    Imports are local to avoid Pylance 'possibly unbound' when Pillow is absent.
+    Emphasize red seven-segment digits using OpenCV (HSV threshold + dilate + invert).
+    Returns a high-contrast L image or None if cv2/numpy are unavailable.
     """
     try:
-        from PIL import ImageOps, ImageFilter  # type: ignore
-        g = ImageOps.grayscale(img)
-        g = ImageOps.autocontrast(g)
-        g = g.filter(ImageFilter.SHARPEN)
-        return g
+        import cv2  # type: ignore
+        import numpy as np  # type: ignore
+        from PIL import Image  # type: ignore
+
+        # PIL -> BGR
+        np_img = np.array(img_pil.convert("RGB"))[:, :, ::-1]
+        hsv = cv2.cvtColor(np_img, cv2.COLOR_BGR2HSV)
+
+        # two red bands in HSV; use uint8 arrays to appease type checkers & cv2
+        lower1 = np.array([0, 80, 60], dtype=np.uint8)
+        upper1 = np.array([10, 255, 255], dtype=np.uint8)
+        lower2 = np.array([170, 80, 60], dtype=np.uint8)
+        upper2 = np.array([180, 255, 255], dtype=np.uint8)
+
+        mask1 = cv2.inRange(hsv, lower1, upper1)
+        mask2 = cv2.inRange(hsv, lower2, upper2)
+        mask = cv2.bitwise_or(mask1, mask2)
+
+        # thicken strokes
+        kernel = np.ones((3, 3), np.uint8)
+        mask = cv2.dilate(mask, kernel, iterations=1)
+
+        # invert (dark digits on light bg often OCR better)
+        inv = cv2.bitwise_not(mask)
+
+        # back to PIL L
+        return Image.fromarray(inv)
     except Exception:
-        # If Pillow pieces not available, return original image
+        return None
+
+def _preprocess(img: PILImageLike) -> PILImageLike:
+    """
+    Prefer OpenCV red-mask; else fallback to PIL autocontrast + threshold + sharpen.
+    """
+    cv_img = _cv_red_mask(img)
+    if cv_img is not None:
+        return cv_img
+
+    # Fallback: PIL-only pipeline
+    try:
+        from PIL import ImageOps, ImageFilter  # type: ignore
+        # Use red channel if available
+        try:
+            r = img.split()[0]  # R from RGB
+        except Exception:
+            r = img
+        r = ImageOps.autocontrast(r)
+
+        # gentler threshold so thin segments survive
+        th = 110
+        lut = ([0] * (th + 1)) + ([255] * (255 - th))
+        r = r.point(lut, mode="1").convert("L")
+
+        r = r.filter(ImageFilter.SHARPEN)
+        return r
+    except Exception:
         return img
 
+def _ocr_digits_line(img: Any, *, allow_colon: bool = False, allow_minus: bool = False) -> str:
+    wl = "0123456789"
+    if allow_colon:
+        wl += ":"
+    if allow_minus:
+        wl += "-"
+    cfg = f"--oem 1 --psm 7 -c tessedit_char_whitelist={wl}"
+    return _ocr_text(img, cfg)
+
+def _preprocess_soft(img: PILImageLike) -> PILImageLike:
+    """Keep labels like 'Q4': grayscale + autocontrast (no hard threshold)."""
+    try:
+        from PIL import ImageOps  # type: ignore
+        g = ImageOps.grayscale(img)
+        g = ImageOps.autocontrast(g)
+        return g
+    except Exception:
+        return img
+
+def _ocr_quarter_line(img: Any) -> str:
+    # Allow Q, O, T + digits; single-line
+    cfg = "--oem 1 --psm 7 -c tessedit_char_whitelist=QOT01234"
+    return _ocr_text(img, cfg)
+
+# --------------------------- Public API ---------------------------
 
 def extract_scoreboard_from_image(image_path: str | os.PathLike[str]) -> OCRScoreboard:
     """
@@ -91,20 +205,15 @@ def extract_scoreboard_from_image(image_path: str | os.PathLike[str]) -> OCRScor
     Env:
       - TESSERACT_CMD (optional): path to `tesseract` binary if not on PATH
     """
-    # Try to import dependencies lazily so editors don't warn
+    # Lazy import to keep editors happy if packages are missing
     try:
         from PIL import Image  # type: ignore
-    except Exception:
-        log.warning("Pillow (PIL) not installed; returning OCR stub.")
-        return OCRScoreboard(used_stub=True)
-
-    try:
         import pytesseract  # type: ignore
     except Exception:
-        log.warning("pytesseract not installed; returning OCR stub.")
+        log.warning("OCR deps missing; returning stub.")
         return OCRScoreboard(used_stub=True)
 
-    # Configure tesseract binary path if provided
+    # allow overriding tesseract path
     tess_cmd = os.getenv("TESSERACT_CMD")
     if tess_cmd:
         pytesseract.pytesseract.tesseract_cmd = tess_cmd
@@ -114,13 +223,71 @@ def extract_scoreboard_from_image(image_path: str | os.PathLike[str]) -> OCRScor
         raise FileNotFoundError(f"Image not found: {p}")
 
     try:
-        with Image.open(p) as im:  # PIL.Image.Image
-            im = _preprocess(im)
-            # whitelist helpful chars, English by default
-            config = "--psm 6 -c tessedit_char_whitelist=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:-"
-            text = pytesseract.image_to_string(im, lang="eng", config=config) or ""
+        with Image.open(p) as im:
+            base = _preprocess(im)
+            W, H = base.size
+
+            # Soft image keeps white labels like "Q4"
+            soft = _preprocess_soft(im)
+
+            # Region under/near the clock (tweak fractions as needed)
+            def crop_frac_soft(x, y, w, h):
+                return soft.crop((int(x*W), int(y*H), int((x+w)*W), int((y+h)*H)))
+
+            quarter_region = crop_frac_soft(0.40, 0.62, 0.20, 0.20)  # below center clock
+            quarter_txt = _ocr_quarter_line(quarter_region)
+
+
+            # 1) general pass (labels + any digits we can grab)
+            general_cfg = "--oem 1 --psm 6 -c tessedit_char_whitelist=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:-"
+            general_txt = _ocr_text(base, general_cfg)
+
+            # 2) region passes tuned generically:
+            #    left = home score, center = clock, right = away score
+            def crop_frac(x: float, y: float, w: float, h: float):
+                return base.crop((int(x*W), int(y*H), int((x+w)*W), int((y+h)*H)))
+
+            left_region   = crop_frac(0.05, 0.30, 0.25, 0.40)
+            center_region = crop_frac(0.31, 0.25, 0.38, 0.32)
+            right_region  = crop_frac(0.70, 0.30, 0.25, 0.40)
+
+            clock_txt  = _ocr_digits_line(center_region, allow_colon=True)
+            lscore_txt = _ocr_digits_line(left_region, allow_minus=True)
+            rscore_txt = _ocr_digits_line(right_region, allow_minus=True)
+
+            merged = "\n".join([
+                general_txt or "",
+                clock_txt or "",
+                lscore_txt or "",
+                rscore_txt or "",
+                quarter_txt or "",
+            ]).strip()
+
     except Exception as e:
         log.exception("OCR failed: %s", e)
         return OCRScoreboard(used_stub=True)
 
-    return _parse_scoreboard_text(text)
+    # Parse with heuristic
+    result = _parse_scoreboard_text(merged)
+
+    # If score missing but we got two numbers from left/right, stitch them
+    if not result.score:
+        lh = re.search(r"\b(\d{1,2})\b", lscore_txt or "")
+        rh = re.search(r"\b(\d{1,2})\b", rscore_txt or "")
+        if lh and rh:
+            result.score = f"{lh.group(1)}-{rh.group(1)}"
+
+    # If quarter missing, try from general text
+    if not result.quarter:
+        q = re.search(r"\b(Q[1-4]|OT)\b", (general_txt or "").upper())
+        if q:
+            result.quarter = q.group(1)
+
+    # If clock missing, take from focused pass
+    if not result.clock and clock_txt:
+        c = re.search(r"\b([0-5]?\d:[0-5]\d)\b", clock_txt)
+        if c:
+            result.clock = c.group(1)
+
+    result.ocr_text = merged
+    return result


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(ocr): add scoreboard OCR service with safe type hints + fallback

## Summary
- Added backend/services/ocr.py with a practical pipeline:
OpenCV HSV red-mask + dilation (fallback to PIL path) for seven-segment digits.
Focused region passes for left/right scores and center clock.
Parser fallbacks for glued outputs (e.g., 0:4224 → score 21-24) and Q4 misreads (:4 → Q4).
- Type-safe PILImageLike alias to keep Pylance happy without hard Pillow dep at import time.
- Keeps graceful stubs if Tesseract/Pillow/OpenCV are missing.

## Testing
- Generated synthetic scoreboard image:
python - <<'PY'
from PIL import Image, ImageDraw, ImageFont
from pathlib import Path
out = Path("data/tmp/score_synth.png"); out.parent.mkdir(parents=True, exist_ok=True)
W,H=1200,300
img = Image.new("RGB",(W,H),(20,20,20)); d = ImageDraw.Draw(img)
try:
    font = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial Bold.ttf", 140)
    small = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial Bold.ttf", 60)
except Exception:
    font = small = ImageFont.load_default()
d.text((40,30),"HOME",fill=(220,220,220),font=small)
d.text((980,30),"GUEST",fill=(220,220,220),font=small)
d.text((60,110),"21",fill=(220,30,30),font=font)
d.text((1020,110),"24",fill=(220,30,30),font=font)
d.text((520,90),"0:42",fill=(220,30,30),font=font)
d.text((560,230),"Q4",fill=(220,220,220),font=small)
img.save(out); print("Wrote", out)
PY
- Ran OCR:
python - <<'PY'
from backend.services.ocr import extract_scoreboard_from_image
print(extract_scoreboard_from_image("data/tmp/score_synth.png").to_dict())
PY
Result: {'score': '21-24', 'clock': '0:42', 'quarter': 'Q4', ...}

## Next Steps
- [ ] Add /ocr/scoreboard POST endpoint (accept image or frame path; return parsed fields + debug).
- [ ] Make crop regions configurable per game template (env/JSON).
- [ ] Add a confidence/validity check (only auto-fill when clock + two scores exist).
- [ ] Optional Vision fallback when OCR fails (OpenAI/Anthropic vision).
- [ ] Wire a “Auto-fill from frame” button in the UI.