### PR TITLE
feat(tts-tone-bias): add tone-aware and bias-aware TTS + LLM prompt generation

### DIFF
--- a/backend/services/tone_profiles.py
+++ b/backend/services/tone_profiles.py
@@ -2,8 +2,7 @@
 from __future__ import annotations
 from typing import Dict, Any
 
-# Expandable library of tone presets for LLM prompting.
-# Keep these short and opinionated so style changes are obvious.
+# ---- Tone presets (unchanged, but easy to extend) ----
 TONE_PRESETS: Dict[str, Dict[str, Any]] = {
     "hype": {
         "system": (
@@ -34,26 +33,55 @@ def normalize_tone(tone: str | None) -> str:
     t = (tone or "").strip().lower()
     return t if t in TONE_PRESETS else "neutral"
 
+# ---- Bias normalization + small guideline snippets ----
+def normalize_bias(bias: str | None) -> str:
+    b = (bias or "").strip().lower()
+    return b if b in {"neutral", "home", "away"} else "neutral"
+
+def _bias_guideline(bias: str, home: str, away: str) -> str:
+    if bias == "home":
+        return (
+            f"Prioritize {home} events. Favor their perspective subtly (occasional 'we/us' ok). "
+            f"Downplay {away} successes. Keep it believable."
+        )
+    if bias == "away":
+        return (
+            f"Prioritize {away} events. Favor their perspective subtly (occasional 'we/us' ok). "
+            f"Downplay {home} successes. Keep it believable."
+        )
+    return "Call both sides fairly; avoid loaded adjectives; keep balance and clarity."
+
 def build_llm_prompt(context: dict, transcript: str | None = None) -> str:
     """
-    Builds a compact, tone-aware prompt. Keeps transcript short for latency.
+    Builds a compact, tone- and bias-aware prompt.
+    - Tone: selects system style + target length
+    - Bias: shapes POV/guidelines (neutral/home/away)
     """
     tone = normalize_tone(context.get("tone"))
+    bias = normalize_bias(context.get("bias"))
+
     preset = TONE_PRESETS[tone]
     sport = (context.get("sport") or "football").strip() or "football"
+    home = (context.get("home_team") or "Home").strip() or "Home"
+    away = (context.get("away_team") or "Away").strip() or "Away"
 
+    pov = "balanced, impartial" if bias == "neutral" else (f"favor {home}" if bias == "home" else f"favor {away}")
+    bias_rules = _bias_guideline(bias, home, away)
+
+    # Keep transcript short for latency; still useful for context
     snippet = (transcript or "").strip()
     if len(snippet) > 1200:
         snippet = snippet[:1200] + " …"
 
-    # System guidance (not a separate chat role here—embedded since we call .generate(prompt))
     sys = preset["system"]
     length_hint = preset["length_hint"]
 
+    # Single-string prompt (works with current llm.generate(prompt))
     return (
         f"{sys}\n"
-        f"Sport: {sport}. Tone: {tone}. Target length: {length_hint}.\n"
-        f"Use the provided context if relevant. Avoid profanity.\n\n"
+        f"Sport: {sport}. Tone: {tone}. POV: {pov}. Target length: {length_hint}.\n"
+        f"Bias guideline: {bias_rules}\n"
+        f"If team names are known, mention them naturally. Avoid profanity.\n\n"
         f"CONTEXT: {context}\n\n"
         f"TRANSCRIPT: {snippet}\n\n"
         f"Commentary:"

--- a/frontend/src/pages/Commentator.jsx
+++ b/frontend/src/pages/Commentator.jsx
@@ -10,6 +10,7 @@ export default function Commentator() {
     quarter: "Q4",
     clock: "0:42",
     tone: "hype",
+    bias: "neutral", // NEW
     voice: "default",
   });
   const [audioOnly, setAudioOnly] = useState(false);
@@ -80,6 +81,7 @@ export default function Commentator() {
       quarter: "Q4",
       clock: "0:42",
       tone: "hype",
+      bias: "neutral", // NEW
       voice: "default",
     });
   }
@@ -110,21 +112,58 @@ export default function Commentator() {
         </div>
 
         <div style={{ display: "grid", gap: 8, gridTemplateColumns: "1fr 1fr" }}>
-          <input placeholder="Home" value={form.home_team}
-                 onChange={(e) => setForm({ ...form, home_team: e.target.value })} disabled={loading}/>
-          <input placeholder="Away" value={form.away_team}
-                 onChange={(e) => setForm({ ...form, away_team: e.target.value })} disabled={loading}/>
-          <input placeholder="Score (e.g., 21-24)" value={form.score}
-                 onChange={(e) => setForm({ ...form, score: e.target.value })} disabled={loading}/>
-          <input placeholder="Quarter (Q1–Q4/OT)" value={form.quarter}
-                 onChange={(e) => setForm({ ...form, quarter: e.target.value })} disabled={loading}/>
-          <input placeholder="Clock (e.g., 0:42)" value={form.clock}
-                 onChange={(e) => setForm({ ...form, clock: e.target.value })} disabled={loading}/>
-          <select value={form.tone} onChange={(e) => setForm({ ...form, tone: e.target.value })} disabled={loading}>
-            <option value="hype">hype</option>
-            <option value="neutral">neutral</option>
-            <option value="radio">radio</option>
-          </select>
+          <input
+            placeholder="Home"
+            value={form.home_team}
+            onChange={(e) => setForm({ ...form, home_team: e.target.value })}
+            disabled={loading}
+          />
+          <input
+            placeholder="Away"
+            value={form.away_team}
+            onChange={(e) => setForm({ ...form, away_team: e.target.value })}
+            disabled={loading}
+          />
+          <input
+            placeholder="Score (e.g., 21-24)"
+            value={form.score}
+            onChange={(e) => setForm({ ...form, score: e.target.value })}
+            disabled={loading}
+          />
+          <input
+            placeholder="Quarter (Q1–Q4/OT)"
+            value={form.quarter}
+            onChange={(e) => setForm({ ...form, quarter: e.target.value })}
+            disabled={loading}
+          />
+          <input
+            placeholder="Clock (e.g., 0:42)"
+            value={form.clock}
+            onChange={(e) => setForm({ ...form, clock: e.target.value })}
+            disabled={loading}
+          />
+          <div style={{ display: "flex", gap: 8 }}>
+            <select
+              value={form.tone}
+              onChange={(e) => setForm({ ...form, tone: e.target.value })}
+              disabled={loading}
+            >
+              <option value="hype">hype</option>
+              <option value="neutral">neutral</option>
+              <option value="radio">radio</option>
+            </select>
+            {/* NEW: Bias selector */}
+            <select
+              value={form.bias}
+              onChange={(e) => setForm({ ...form, bias: e.target.value })}
+              disabled={loading}
+              title="Commentator POV bias"
+            >
+              <option value="neutral">bias: neutral</option>
+              <option value="home">bias: home</option>
+              <option value="away">bias: away</option>
+            </select>
+          </div>
         </div>
 
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
@@ -134,7 +173,9 @@ export default function Commentator() {
           <button onClick={onDemoMode} disabled={loading}>
             Demo Mode (prefilled backup)
           </button>
-          <button onClick={onReset} disabled={loading}>Reset</button>
+          <button onClick={onReset} disabled={loading}>
+            Reset
+          </button>
           {!canAnalyze && (
             <span style={{ marginLeft: 8, color: "#b45309", fontSize: 12 }}>
               Select a clip or enable “Audio only”.
@@ -155,25 +196,45 @@ export default function Commentator() {
               <div>
                 <h3>Audio</h3>
                 <audio controls src={staticUrl(resp.audio_url)} />
-                <div><a href={staticUrl(resp.audio_url)} download>Download audio</a></div>
+                <div>
+                  <a href={staticUrl(resp.audio_url)} download>
+                    Download audio
+                  </a>
+                </div>
               </div>
             )}
 
             {resp.video_url && (
               <div>
                 <h3>Dubbed Video</h3>
-                <video controls src={staticUrl(resp.video_url)} style={{ width: "100%", borderRadius: 8 }} />
-                <div><a href={staticUrl(resp.video_url)} download>Download video</a></div>
+                <video
+                  controls
+                  src={staticUrl(resp.video_url)}
+                  style={{ width: "100%", borderRadius: 8 }}
+                />
+                <div>
+                  <a href={staticUrl(resp.video_url)} download>
+                    Download video
+                  </a>
+                </div>
               </div>
             )}
 
             <small>
-              Latency: {resp.meta?.duration_s != null ? resp.meta.duration_s.toFixed?.(3) : "—"}s
+              Latency:{" "}
+              {resp.meta?.duration_s != null
+                ? resp.meta.duration_s.toFixed?.(3)
+                : "—"}
               {resp.meta?.usedManualContext ? " • manual context" : ""}
               {resp.meta?.audio_only ? " • audio-only" : ""}
               {resp.meta?.prompt_tone ? ` • tone: ${resp.meta.prompt_tone}` : ""}
+              {resp.meta?.prompt_bias ? ` • bias: ${resp.meta.prompt_bias}` : ""}
             </small>
-            {resp.meta?.errors && <pre style={{ color: "crimson" }}>{JSON.stringify(resp.meta.errors, null, 2)}</pre>}
+            {resp.meta?.errors && (
+              <pre style={{ color: "crimson" }}>
+                {JSON.stringify(resp.meta.errors, null, 2)}
+              </pre>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(tts-tone-bias): add tone-aware and bias-aware TTS + LLM prompt generation

## Summary
- Added tone-aware settings for ElevenLabs TTS (hype, radio, neutral) and preserved OpenAI fallback.
- Refactored tone_profiles.py to support bias control (neutral, home, away) when building LLM prompts.
- Updated analyze_commentate route to pass tone through to both LLM + TTS.
- Extended Commentator.jsx frontend to show meta fields for tone/bias/audio-only.

## Testing
- Local run: uvicorn main:app --reload
- Frontend form works with:
video upload
audio-only mode
different tone presets
bias presets (manual context)
- Verified ElevenLabs API responses respect stability/similarity settings per tone.
- LLM prompt now shows bias/tone fields in meta.

## Next Steps
- [x] Add UI control for selecting bias (currently backend-only via context).
- [ ] Expand tone/bias presets with more styles (e.g., sarcastic, dramatic).
- [ ] Add caching/retry for TTS calls to improve resilience.
