### PR TITLE
feat(ocr): add /ocr/image and /ocr/video routers; fix type safety for used_stub

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -471,3 +471,6 @@ app.include_router(prewarm_router)
 
 from backend.routers.prewarm import router as prewarm_router
 app.include_router(prewarm_router)
+
+from backend.routers.ocr_api import router as ocr_router
+app.include_router(ocr_router)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,6 +38,11 @@ typing-inspection==0.4.1
 typing_extensions==4.14.1
 urllib3==2.5.0
 uvicorn==0.35.0
+pillow>=10.3.0
+opencv-python-headless>=4.10.0.84
+pytesseract>=0.3.10
+numpy>=1.26.4
+rapidfuzz>=3.9.5
 
 # Dev tools
 black

--- a/backend/routers/ocr_api.py
+++ b/backend/routers/ocr_api.py
@@ -1,0 +1,129 @@
+# backend/routers/ocr_api.py
+from __future__ import annotations
+from fastapi import APIRouter, UploadFile, File, HTTPException, Form
+from pydantic import BaseModel
+from typing import Optional
+from pathlib import Path
+import shutil
+import os
+import uuid
+
+from backend.services.ocr import extract_scoreboard_from_image
+from backend.services.ocr_from_video import extract_scoreboard_from_video
+
+router = APIRouter(prefix="/ocr", tags=["ocr"])
+
+TMP_DIR = Path(os.getenv("DATA_DIR", "data")) / "tmp" / "uploads"
+TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+# ---------- Schemas ----------
+
+class OCRImageResponse(BaseModel):
+    home_team: Optional[str]
+    away_team: Optional[str]
+    score: Optional[str]
+    quarter: Optional[str]
+    clock: Optional[str]
+    ocr_text: Optional[str]
+    used_stub: bool
+    width: Optional[int] = None
+    height: Optional[int] = None
+    debug_dir: Optional[str] = None
+    boxes_png: Optional[str] = None
+
+class OCRVideoResponse(BaseModel):
+    home_team: Optional[str]
+    away_team: Optional[str]
+    score: Optional[str]
+    quarter: Optional[str]
+    clock: Optional[str]
+    ocr_text: Optional[str]
+    used_stub: bool
+    sampled_from_s: float
+
+# ---------- Endpoints ----------
+
+@router.post("/image", response_model=OCRImageResponse)
+async def ocr_image(
+    image: UploadFile = File(...),
+    debug: bool = Form(False),
+    viz: bool = Form(False),
+    dx: int = Form(0),
+    dy: int = Form(0),
+):
+    try:
+        # Save upload to tmp
+        uid = uuid.uuid4().hex
+        dest = TMP_DIR / f"{uid}_{image.filename}"
+        with dest.open("wb") as f:
+            shutil.copyfileobj(image.file, f)
+
+        # Run your existing OCR
+        result = extract_scoreboard_from_image(
+            str(dest),
+            debug_crops=debug,
+            viz_boxes_flag=viz,
+            dx=dx,
+            dy=dy,
+        )
+        out = result.to_dict()  # mixed types inside (str|None + bool)
+
+        # Image size metadata (optional)
+        width = height = None
+        try:
+            from PIL import Image  # type: ignore
+            with Image.open(dest) as im:
+                width, height = im.size
+        except Exception:
+            pass
+
+        # Pylance-friendly explicit mapping (and force bool for used_stub)
+        return OCRImageResponse(
+            home_team = out.get("home_team"),
+            away_team = out.get("away_team"),
+            score     = out.get("score"),
+            quarter   = out.get("quarter"),
+            clock     = out.get("clock"),
+            ocr_text  = out.get("ocr_text"),
+            used_stub = bool(out.get("used_stub", False)),
+            width=width, height=height,
+            debug_dir = "data/tmp/ocr_debug" if debug else None,
+            boxes_png = "data/tmp/ocr_debug/boxes.png" if viz else None,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"OCR failed: {e}")
+
+@router.post("/video", response_model=OCRVideoResponse)
+async def ocr_video(
+    video: UploadFile = File(...),
+    viz: bool = Form(False),
+    dx: int = Form(0),
+    dy: int = Form(0),
+    t: float = Form(0.10),
+):
+    try:
+        uid = uuid.uuid4().hex
+        dest = TMP_DIR / f"{uid}_{video.filename}"
+        with dest.open("wb") as f:
+            shutil.copyfileobj(video.file, f)
+
+        data = extract_scoreboard_from_video(
+            str(dest),
+            viz=viz,
+            dx=dx,
+            dy=dy,
+            t=t,
+        )
+
+        return OCRVideoResponse(
+            home_team=data.get("home_team"),
+            away_team=data.get("away_team"),
+            score=data.get("score"),
+            quarter=data.get("quarter"),
+            clock=data.get("clock"),
+            ocr_text=data.get("ocr_text"),
+            used_stub=bool(data.get("used_stub", False)),
+            sampled_from_s=float(t),
+        )
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"OCR(video) failed: {e}")

--- a/backend/services/ocr.py
+++ b/backend/services/ocr.py
@@ -36,7 +36,7 @@ class OCRScoreboard:
     ocr_text:  Optional[str] = None
     used_stub: bool = False
 
-    def to_dict(self) -> Dict[str, Optional[str]]:
+    def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
 
 # --------------------------- Reference layout (pixels) ---------------------------


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(ocr): add API endpoints for image/video OCR and fix used_stub typing

## Summary
- Adds POST /ocr/image and POST /ocr/video, wrapping existing services/ocr*.py.
- Router explicitly maps fields and coerces used_stub to bool (Pylance-safe).
- (Optional) Tightens OCRScoreboard.to_dict() typing to avoid future mismatches.

## Testing
uvicorn main:app --reload
curl -F "image=@data/tmp/scorebar.png" -F "viz=true" http://localhost:8000/ocr/image | jq .
curl -F "video=@Madden\ Clip.mp4" -F "viz=true" -F "t=0.10" http://localhost:8000/ocr/video | jq .

## Next Steps
- [ ] Link to frontend
- [ ] Ocr finding dictate llm prompt generation

