### PR TITLE
feat(frontend): video-only one-shot commentary via /pipeline/run-commentary-from-video

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,41 +1,111 @@
 // frontend/src/lib/api.js
+// Centralized API helpers for Mr. TAI frontend
+
+// Base URL (no trailing slash)
 const RAW_API_BASE = import.meta?.env?.VITE_API_BASE ?? "http://localhost:8000";
-// trim any trailing slashes
 export const API_BASE = RAW_API_BASE.replace(/\/+$/, "");
 
-export async function getHealth() {
-  const res = await fetch(`${API_BASE}/health`);
-  if (!res.ok) throw new Error(`Health check failed: ${res.status}`);
-  return res.json();
+// ---- Utilities ----
+function toUrl(path) {
+  return `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
 }
 
-export async function uploadFile(file) {
-  const form = new FormData();
-  form.append("file", file);
-
-  const res = await fetch(`${API_BASE}/upload`, {
-    method: "POST",
-    body: form,
-  });
-  if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
-  return res.json();
-}
-
-export async function analyzeCommentate({ file, tone = "play-by-play", audioOnly = false, extra = {} }) {
-  const API_BASE = import.meta?.env?.VITE_API_BASE?.replace(/\/+$/, "") || "http://127.0.0.1:8000";
-  const form = new FormData();
-  if (file) form.append("file", file);
-  form.append("tone", tone);
-  form.append("audio_only", String(audioOnly));
-  // optional extras (home_team, score, etc.)
-  for (const [k, v] of Object.entries(extra)) {
-    if (v != null && v !== "") form.append(k, v);
-  }
-
-  const res = await fetch(`${API_BASE}/analyze_commentate`, { method: "POST", body: form });
+async function httpJson(url, init = {}) {
+  const res = await fetch(url, init);
   if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`analyze_commentate failed: ${res.status} ${text}`);
+    const msg = await res.text().catch(() => "");
+    throw new Error(`${init.method || "GET"} ${url} failed: ${res.status} ${msg}`);
   }
   return res.json();
 }
+
+// ---- Health ----
+export async function getHealth() {
+  return httpJson(toUrl("/health"));
+}
+
+// ---- OCR (optional helpers for debugging/manual use) ----
+export async function runOcrImage(file, { viz = false, debug = false, dx = 0, dy = 0 } = {}) {
+  const fd = new FormData();
+  fd.append("image", file);
+  fd.append("viz", String(viz));
+  fd.append("debug", String(debug));
+  fd.append("dx", String(dx));
+  fd.append("dy", String(dy));
+  return httpJson(toUrl("/ocr/image"), { method: "POST", body: fd });
+}
+
+export async function runOcrVideo(file, { viz = false, dx = 0, dy = 0, t = 0.1 } = {}) {
+  const fd = new FormData();
+  fd.append("video", file);
+  fd.append("viz", String(viz));
+  fd.append("dx", String(dx));
+  fd.append("dy", String(dy));
+  fd.append("t", String(t));
+  return httpJson(toUrl("/ocr/video"), { method: "POST", body: fd });
+}
+
+// ---- One-shot pipeline (recommended) ----
+// Upload *only* a video; backend does OCR → LLM → TTS → (optional) mux.
+export async function runCommentaryFromVideo(
+  file,
+  { tone = "play-by-play", bias = "neutral", audioOnly = false, viz = false, dx = 0, dy = 0, t = 0.1 } = {}
+) {
+  const fd = new FormData();
+  fd.append("video", file);
+  fd.append("tone", tone);
+  fd.append("bias", bias);
+  fd.append("audio_only", String(audioOnly));
+  // passthrough diagnostic knobs (unused is fine)
+  fd.append("viz", String(viz));
+  fd.append("dx", String(dx));
+  fd.append("dy", String(dy));
+  fd.append("t", String(t));
+  return httpJson(toUrl("/pipeline/run-commentary-from-video"), { method: "POST", body: fd });
+}
+
+// ---- Legacy: direct analyze endpoint (kept for compatibility) ----
+// If other pages still call /analyze_commentate, this keeps them working.
+// Prefer runCommentaryFromVideo for the new flow.
+export async function analyzeCommentate(
+  file,
+  {
+    home_team = null,
+    away_team = null,
+    score = null,
+    quarter = null,
+    clock = null,
+    tone = "play-by-play",
+    bias = "neutral",
+    voice = "default",
+    audio_only = false,
+  } = {}
+) {
+  const fd = new FormData();
+  if (file) fd.append("file", file);
+  if (home_team != null) fd.append("home_team", String(home_team));
+  if (away_team != null) fd.append("away_team", String(away_team));
+  if (score != null) fd.append("score", String(score));
+  if (quarter != null) fd.append("quarter", String(quarter));
+  if (clock != null) fd.append("clock", String(clock));
+  fd.append("tone", tone);
+  fd.append("bias", bias);
+  fd.append("voice", voice);
+  fd.append("audio_only", String(audio_only));
+  return httpJson(toUrl("/analyze_commentate"), { method: "POST", body: fd });
+}
+
+// ---- Helpers for building absolute static URLs in the UI ----
+export function staticUrl(pathOrNull) {
+  return pathOrNull ? toUrl(pathOrNull) : "";
+}
+
+export default {
+  API_BASE,
+  getHealth,
+  runOcrImage,
+  runOcrVideo,
+  runCommentaryFromVideo,
+  analyzeCommentate,
+  staticUrl,
+};

--- a/frontend/src/pages/Commentator.jsx
+++ b/frontend/src/pages/Commentator.jsx
@@ -1,267 +1,78 @@
+// frontend/src/pages/Commentator.jsx
 import React, { useState } from "react";
-import { API_BASE } from "../lib/api";
+import { API_BASE, runCommentaryFromVideo } from "../lib/api";
 
 export default function Commentator() {
   const [file, setFile] = useState(null);
-  const [form, setForm] = useState({
-    home_team: "USC",
-    away_team: "UCLA",
-    score: "21-24",
-    quarter: "Q4",
-    clock: "0:42",
-    tone: "hype",
-    bias: "neutral",
-    voice: "default",
-  });
-  const [audioOnly, setAudioOnly] = useState(false);
   const [loading, setLoading] = useState(false);
   const [resp, setResp] = useState(null);
-  const [error, setError] = useState(null);
+  const [err, setErr] = useState("");
 
+  const canRun = !!file;
   const staticUrl = (u) => (u ? `${API_BASE}${u}` : "");
 
-  async function onSubmit() {
-    if (!file && !audioOnly) {
-      return setError("Select a clip or enable “Audio only”.");
-    }
-    setError(null);
-    setLoading(true);
-    setResp(null);
-
-    const body = new FormData();
-    if (file) body.append("file", file);
-    Object.entries(form).forEach(([k, v]) => body.append(k, v));
-    body.append("audio_only", String(audioOnly));
-
+  async function onRun() {
+    if (!file) return;
+    setErr(""); setResp(null); setLoading(true);
     try {
-      const r = await fetch(`${API_BASE}/analyze_commentate`, { method: "POST", body });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const j = await r.json();
-      setResp(j);
+      const data = await runCommentaryFromVideo(file, { tone: "play-by-play", bias: "neutral", audioOnly: false });
+      setResp(data);
     } catch (e) {
-      setError(e?.message || "Request failed");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function onDemoMode() {
-    setError(null);
-    setLoading(true);
-    setResp(null);
-    try {
-      const r = await fetch(`${API_BASE}/demo/artifacts`);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const j = await r.json();
-      setResp({
-        id: "demo",
-        text: j.text || "Demo commentary",
-        audio_url: j.audio_url || null,
-        video_url: j.video_url || null,
-        meta: { duration_s: 0, errors: null, usedManualContext: false },
-      });
-    } catch (e) {
-      setError(e?.message || "Failed to load demo artifacts");
+      setErr(String(e.message || e));
     } finally {
       setLoading(false);
     }
   }
 
   function onReset() {
-    setFile(null);
-    setResp(null);
-    setError(null);
-    setAudioOnly(false);
-    setForm({
-      home_team: "USC",
-      away_team: "UCLA",
-      score: "21-24",
-      quarter: "Q4",
-      clock: "0:42",
-      tone: "hype",
-      bias: "neutral",
-      voice: "default",
-    });
+    setFile(null); setResp(null); setErr("");
   }
 
-  const canAnalyze = !!file || audioOnly;
-  const labelStyle = { display: "grid", gap: 6, fontSize: 12, color: "#374151", lineHeight: 1.25 };
-  const inputStyle = { padding: 8, border: "1px solid #d1d5db", borderRadius: 6 };
-
   return (
-    <div style={{ maxWidth: 720, margin: "40px auto", padding: 16 }}>
-      <h1>Mr. TAI — Madden Commentator (MVP)</h1>
+    <div style={{ maxWidth: 840, margin: "40px auto", padding: 16 }}>
+      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 12 }}>Mr. TAI • One-Shot Commentary</h1>
 
-      <div style={{ display: "grid", gap: 12, marginTop: 16 }}>
-        <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
-          <label style={{ ...labelStyle, margin: 0 }}>
-            <span>Clip (video/audio)</span>
-            <input
-              type="file"
-              accept="video/mp4,video/*,audio/*"
-              onChange={(e) => setFile(e.target.files?.[0] || null)}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <input
-              type="checkbox"
-              checked={audioOnly}
-              onChange={(e) => setAudioOnly(e.target.checked)}
-              disabled={loading}
-            />
-            <span>Audio only (no clip)</span>
-          </label>
-        </div>
-
-        {/* Two-column, one-field-per-cell to avoid vertical offset */}
-        <div style={{ display: "grid", gap: 10, gridTemplateColumns: "1fr 1fr", alignItems: "end" }}>
-          <label style={labelStyle}>
-            <span>Home Team</span>
-            <input
-              style={inputStyle}
-              value={form.home_team}
-              onChange={(e) => setForm({ ...form, home_team: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Away Team</span>
-            <input
-              style={inputStyle}
-              value={form.away_team}
-              onChange={(e) => setForm({ ...form, away_team: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Score</span>
-            <input
-              style={inputStyle}
-              placeholder="e.g., 21-24"
-              value={form.score}
-              onChange={(e) => setForm({ ...form, score: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Quarter</span>
-            <input
-              style={inputStyle}
-              placeholder="Q1–Q4/OT"
-              value={form.quarter}
-              onChange={(e) => setForm({ ...form, quarter: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Clock</span>
-            <input
-              style={inputStyle}
-              placeholder="e.g., 0:42"
-              value={form.clock}
-              onChange={(e) => setForm({ ...form, clock: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Tone</span>
-            <select
-              style={inputStyle}
-              value={form.tone}
-              onChange={(e) => setForm({ ...form, tone: e.target.value })}
-              disabled={loading}
-            >
-              <option value="hype">hype</option>
-              <option value="neutral">neutral</option>
-              <option value="radio">radio</option>
-            </select>
-          </label>
-
-          {/* spacer to keep symmetry */}
-          <div aria-hidden="true" />
-
-          <label style={labelStyle}>
-            <span>Bias (POV)</span>
-            <select
-              style={inputStyle}
-              value={form.bias}
-              onChange={(e) => setForm({ ...form, bias: e.target.value })}
-              disabled={loading}
-              title="Commentator POV bias"
-            >
-              <option value="neutral">neutral</option>
-              <option value="home">home</option>
-              <option value="away">away</option>
-            </select>
-          </label>
-        </div>
-
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <button onClick={onSubmit} disabled={loading || !canAnalyze}>
-            {loading ? "Working…" : "Analyze & Commentate"}
+      <div style={{ display: "grid", gap: 10, gridTemplateColumns: "1fr auto" }}>
+        <input type="file" accept="video/*" onChange={(e) => setFile(e.target.files?.[0] || null)} disabled={loading} />
+        <div style={{ display: "flex", gap: 8 }}>
+          <button onClick={onRun} disabled={!canRun || loading} style={{ padding: "8px 12px" }}>
+            {loading ? "Running…" : "Run Commentary"}
           </button>
-          <button onClick={onDemoMode} disabled={loading}>
-            Demo Mode (prefilled backup)
-          </button>
-          <button onClick={onReset} disabled={loading}>
-            Reset
-          </button>
-          {!canAnalyze && (
-            <span style={{ marginLeft: 8, color: "#b45309", fontSize: 12 }}>
-              Select a clip or enable “Audio only”.
-            </span>
-          )}
+          <button onClick={onReset} disabled={loading} style={{ padding: "8px 12px" }}>Reset</button>
         </div>
+      </div>
 
-        {error && <div style={{ color: "crimson" }}>{error}</div>}
+      {!canRun && <div style={{ marginTop: 8, color: "#b45309", fontSize: 12 }}>Select a video to continue.</div>}
+      {err && <div style={{ marginTop: 12, color: "crimson" }}>{err}</div>}
 
-        {resp && (
-          <div style={{ marginTop: 16, display: "grid", gap: 12 }}>
-            <div>
-              <h3>Commentary Text</h3>
-              <p style={{ whiteSpace: "pre-wrap" }}>{resp.text}</p>
-            </div>
+      {resp && (
+        <div style={{ marginTop: 20, display: "grid", gap: 16 }}>
+          <div style={{ padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+            <div style={{ fontWeight: 600, marginBottom: 6 }}>Commentary Text</div>
+            <pre style={{ whiteSpace: "pre-wrap", margin: 0 }}>{resp.text}</pre>
+          </div>
 
+          <div style={{ display: "grid", gap: 16 }}>
             {resp.audio_url && (
-              <div>
-                <h3>Audio</h3>
+              <div style={{ padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Audio</div>
                 <audio controls src={staticUrl(resp.audio_url)} />
-                <div><a href={staticUrl(resp.audio_url)} download>Download audio</a></div>
               </div>
             )}
-
             {resp.video_url && (
-              <div>
-                <h3>Dubbed Video</h3>
-                <video
-                  controls
-                  src={staticUrl(resp.video_url)}
-                  style={{ width: "100%", borderRadius: 8 }}
-                />
-                <div><a href={staticUrl(resp.video_url)} download>Download video</a></div>
+              <div style={{ padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Dubbed Video</div>
+                <video controls width={640} src={staticUrl(resp.video_url)} />
               </div>
-            )}
-
-            <small>
-              Latency: {resp.meta?.duration_s != null ? resp.meta.duration_s.toFixed?.(3) : "—"}s
-              {resp.meta?.usedManualContext ? " • manual context" : ""}
-              {resp.meta?.audio_only ? " • audio-only" : ""}
-              {resp.meta?.prompt_tone ? ` • tone: ${resp.meta.prompt_tone}` : ""}
-              {resp.meta?.prompt_bias ? ` • bias: ${resp.meta.prompt_bias}` : ""}
-            </small>
-            {resp.meta?.errors && (
-              <pre style={{ color: "crimson" }}>{JSON.stringify(resp.meta.errors, null, 2)}</pre>
             )}
           </div>
-        )}
-      </div>
+
+          <div style={{ padding: 12, border: "1px solid #eee", borderRadius: 8 }}>
+            <div style={{ fontWeight: 600, marginBottom: 6 }}>Meta</div>
+            <pre style={{ margin: 0, fontSize: 12 }}>{JSON.stringify(resp.meta, null, 2)}</pre>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(frontend): video-only one-shot commentary

## Summary
- Replace param form with single video upload hitting /pipeline/run-commentary-from-video.
- Shows returned text, audio_url, video_url.

## Testing
- Backend: uvicorn main:app --reload.
- Frontend: VITE_API_BASE=http://localhost:8000, npm run dev.
- Upload short clip → receive commentary text + playable audio (+ video if muxed).

## Next Steps
- [ ] Remove any legacy param-based UI/routes
- [ ] Add progress states + basic error toasts
