### PR TITLE
feat(tts+frontend): hybrid TTS routing (ElevenLabs+TypeCast stub), env-based tone/bias defaults, UI selectors, and API named-exports cleanup

### DIFF
--- a/backend/services/tts_providers.py
+++ b/backend/services/tts_providers.py
@@ -2,16 +2,14 @@
 from __future__ import annotations
 from typing import Protocol
 from functools import lru_cache
-import pathlib, uuid, os, requests
+import pathlib, uuid, os, time, json, requests
 
 class TTSClient(Protocol):
-    # Accept **kwargs so callers can pass tone/bias without breaking providers.
     def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str: ...
 
 
 # -------- ElevenLabs (tone-aware) --------
 class ElevenLabsTTS:
-    # Tunable per-tone settings (light touch so it still sounds natural).
     TONE_SETTINGS = {
         "hype":    {"stability": 0.45, "similarity_boost": 0.85},
         "radio":   {"stability": 0.65, "similarity_boost": 0.75},
@@ -26,11 +24,6 @@ class ElevenLabsTTS:
         self.model = (os.getenv("ELEVENLABS_MODEL", "eleven_multilingual_v2") or "").strip()
 
     def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
-        """
-        kwargs:
-          - tone: 'hype' | 'radio' | 'neutral' (optional; defaults to neutral)
-          - bias: accepted but ignored here (bias primarily handled in LLM prompt)
-        """
         out_dir = pathlib.Path(out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
         out = out_dir / f"tts_{uuid.uuid4().hex}.mp3"
@@ -44,15 +37,10 @@ class ElevenLabsTTS:
             "accept": "audio/mpeg",
             "content-type": "application/json",
         }
-        payload = {
-            "text": text,
-            "model_id": self.model,
-            "voice_settings": settings,
-        }
+        payload = {"text": text, "model_id": self.model, "voice_settings": settings}
 
         r = requests.post(url, json=payload, headers=headers, timeout=60)
         if r.status_code != 200:
-            # Mask the key if the server echoed it back (defensive).
             snippet = r.text[:200].replace(self.key, "***")
             raise RuntimeError(f"ElevenLabs {r.status_code}: {snippet}")
 
@@ -72,29 +60,18 @@ class OpenAITTS:
         self.voice = (os.getenv("OPENAI_TTS_VOICE", "alloy") or "").strip()
 
     def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
-        """
-        kwargs accepted (tone/bias) but currently unused by OpenAI TTS.
-        """
         out_dir = pathlib.Path(out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
         out = out_dir / f"tts_{uuid.uuid4().hex}.mp3"
 
-        # Preferred: streaming response API (OpenAI v1 SDK)
         try:
             with self.client.audio.speech.with_streaming_response.create(
-                model=self.model,
-                voice=self.voice,
-                input=text,
+                model=self.model, voice=self.voice, input=text
             ) as resp:
                 resp.stream_to_file(str(out))
                 return str(out)
         except AttributeError:
-            # Fallback: older/newer variants that expose .create() with bytes-like content
-            resp = self.client.audio.speech.create(
-                model=self.model,
-                voice=self.voice,
-                input=text,
-            )
+            resp = self.client.audio.speech.create(model=self.model, voice=self.voice, input=text)
             data = getattr(resp, "content", None)
             if data is None and hasattr(resp, "read"):
                 data = resp.read()
@@ -104,117 +81,208 @@ class OpenAITTS:
             return str(out)
 
 
-# -------- TypeCast.AI (stub w/ real API support when configured) --------
+# -------- TypeCast.AI (real integration) --------
 class TypeCastTTS:
     """
-    When TYPECAST_API_KEY is set, call TypeCast API.
-    If not set, gracefully fallback to ElevenLabs (so you can test the flow today).
+    Two strategies:
+      1) POST /v1/text-to-speech (sync) with X-API-KEY (preferred)
+      2) POST /api/speak -> poll GET /api/speak/v2/{id} -> download audio (Bearer token)
     Env:
-      - TYPECAST_API_KEY
-      - TYPECAST_BASE_URL (default: https://api.typecast.ai)
+      - TYPECAST_API_KEY (required)
+      - TYPECAST_BASE_URL (default https://typecast.ai)
       - TYPECAST_DEFAULT_VOICE
-      - TYPECAST_VOICE_MAP (JSON: {"hype|neutral": "voice_id", "radio|neutral": "voice_id", ...})
+      - TYPECAST_VOICE_MAP (JSON: {"hype|neutral":"voice_x", "radio|neutral":"voice_y", ...})
+      - TYPECAST_MODEL (optional; e.g., "ssfm-v21")
+      - TYPECAST_POLL_INTERVAL_MS (default 1000)
+      - TYPECAST_POLL_TIMEOUT_S (default 60)
     """
     def __init__(self):
-        import json
         self.key = (os.getenv("TYPECAST_API_KEY") or "").strip()
-        self.base = (os.getenv("TYPECAST_BASE_URL", "https://api.typecast.ai") or "").rstrip("/")
+        if not self.key:
+            raise RuntimeError("TYPECAST_API_KEY missing")
+        self.base = (os.getenv("TYPECAST_BASE_URL", "https://typecast.ai") or "").rstrip("/")
         self.voice_default = os.getenv("TYPECAST_DEFAULT_VOICE", "typecast_default")
+        self.model = os.getenv("TYPECAST_MODEL", "ssfm-v21")
         try:
             self.voice_map = json.loads(os.getenv("TYPECAST_VOICE_MAP", "{}"))
         except Exception:
             self.voice_map = {}
-        # Prepare ElevenLabs fallback
-        self._fallback_eleven: ElevenLabsTTS | None = None
-        try:
-            self._fallback_eleven = ElevenLabsTTS()
-        except Exception:
-            self._fallback_eleven = None
+        self.poll_interval_ms = int(os.getenv("TYPECAST_POLL_INTERVAL_MS", "1000"))
+        self.poll_timeout_s = int(os.getenv("TYPECAST_POLL_TIMEOUT_S", "60"))
 
     def _pick_voice(self, tone: str | None, bias: str | None) -> str:
         key = f"{(tone or 'neutral').lower()}|{(bias or 'neutral').lower()}"
         return self.voice_map.get(key, self.voice_default)
 
-    def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
-        # If no API key, fallback to ElevenLabs (keeps your pipeline working)
-        if not self.key:
-            if self._fallback_eleven:
-                return self._fallback_eleven.synth_to_file(text, out_dir, **kwargs)
-            raise RuntimeError("TypeCast not configured and ElevenLabs fallback unavailable")
+    # ---------- Strategy 1: /v1/text-to-speech (sync) ----------
+    def _tts_v1_sync(self, text: str, voice_id: str) -> bytes | None:
+        url = f"{self.base}/v1/text-to-speech"
+        headers = {
+            "X-API-KEY": self.key,               # per docs
+            "Authorization": f"Bearer {self.key}",  # some docs/examples use Bearer
+            "Content-Type": "application/json",
+            "Accept": "audio/mpeg,application/json",
+        }
+        payload = {
+            "text": text,
+            "voice_id": voice_id,
+            "model": self.model,
+            # You can add "prompt"/emotion here if desired.
+        }
+        r = requests.post(url, json=payload, headers=headers, timeout=90)
+        if r.status_code >= 400:
+            return None
+        # Either bytes directly or JSON with URL
+        ct = r.headers.get("content-type", "")
+        if "application/json" in ct:
+            try:
+                data = r.json()
+                audio_url = data.get("audio_url")
+                if audio_url:
+                    r2 = requests.get(audio_url, timeout=120)
+                    if r2.status_code < 400:
+                        return r2.content
+            except Exception:
+                return None
+            return None
+        return r.content
 
+    # ---------- Strategy 2: /api/speak (async) ----------
+    def _speak_async(self, text: str, voice_id: str) -> bytes:
+        # Step 1: request synthesis job
+        url = f"{self.base}/api/speak"
+        headers = {
+            "Authorization": f"Bearer {self.key}",
+            "X-API-KEY": self.key,  # belt & suspenders
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "text": text,
+            "actor_id": voice_id,   # docs use "actor"/"voice" terminology; many examples use actor_id
+            "model": self.model,
+        }
+        r = requests.post(url, json=payload, headers=headers, timeout=60)
+        if r.status_code >= 400:
+            raise RuntimeError(f"TypeCast speak error {r.status_code}: {r.text[:200]}")
+        data = r.json()
+        speak_id = data.get("result", {}).get("id") or data.get("id") or data.get("result_id")
+        if not speak_id:
+            raise RuntimeError("TypeCast /api/speak: missing job id")
+
+        # Step 2: poll status
+        status_url = f"{self.base}/api/speak/v2/{speak_id}"
+        t0 = time.time()
+        while True:
+            r2 = requests.get(status_url, headers={"Authorization": f"Bearer {self.key}"}, timeout=30)
+            if r2.status_code >= 400:
+                raise RuntimeError(f"TypeCast poll {r2.status_code}: {r2.text[:200]}")
+            info = r2.json()
+            status = info.get("result", {}).get("status") or info.get("status")
+            if status == "done":
+                # Expect audio_download_url in result
+                dl = (
+                    info.get("result", {}).get("audio_download_url")
+                    or info.get("audio_download_url")
+                    or info.get("result", {}).get("download_url")
+                )
+                if not dl:
+                    raise RuntimeError("TypeCast: done but no audio_download_url")
+                r3 = requests.get(dl, timeout=120)
+                if r3.status_code >= 400:
+                    raise RuntimeError(f"TypeCast download {r3.status_code}")
+                return r3.content
+            if (time.time() - t0) > self.poll_timeout_s:
+                raise RuntimeError("TypeCast poll timeout")
+            time.sleep(self.poll_interval_ms / 1000.0)
+
+    def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
         out_dir = pathlib.Path(out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
         out = out_dir / f"tts_{uuid.uuid4().hex}.mp3"
 
         voice_id = self._pick_voice(kwargs.get("tone"), kwargs.get("bias"))
-        url = f"{self.base}/v1/tts"
-        headers = {"Authorization": f"Bearer {self.key}", "Content-Type": "application/json"}
-        payload = {
-            "voice_id": voice_id,
-            "text": text,
-            # Hint: you can extend with model/emotion/pitch/tempo when you have exact API spec.
-            "metadata": {"tone": kwargs.get("tone"), "bias": kwargs.get("bias")},
-        }
 
-        r = requests.post(url, headers=headers, json=payload, timeout=60)
-        if r.status_code >= 400:
-            raise RuntimeError(f"TypeCast {r.status_code}: {r.text[:200]}")
+        # Try synchronous v1 first (if available)
+        blob = self._tts_v1_sync(text, voice_id)
+        if blob is None:
+            # Fallback to async job flow
+            blob = self._speak_async(text, voice_id)
 
-        # If TypeCast returns JSON with a URL, download; else assume audio bytes.
-        ct = r.headers.get("content-type", "")
-        if "application/json" in ct:
-            data = r.json()
-            audio_url = data.get("audio_url")
-            if not audio_url:
-                raise RuntimeError("TypeCast: no audio_url in response")
-            r2 = requests.get(audio_url, timeout=120)
-            if r2.status_code >= 400:
-                raise RuntimeError(f"TypeCast download {r2.status_code}")
-            out.write_bytes(r2.content)
-        else:
-            out.write_bytes(r.content)
-
+        out.write_bytes(blob)
         return str(out)
 
 
 # -------- Hybrid router --------
+# -------- Hybrid router --------
+class _HybridTTS:
+    def __init__(self, eleven=None, typecast=None, openai=None):
+        self.eleven = eleven
+        self.typecast = typecast
+        self.openai = openai
+
+    def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
+        tone = (kwargs.get("tone") or "neutral").lower()
+        # Route by tone first
+        if tone in {"hype", "radio"} and self.typecast is not None:
+            try:
+                return self.typecast.synth_to_file(text, out_dir, **kwargs)
+            except Exception:
+                # fallback: ElevenLabs -> OpenAI
+                if self.eleven is not None:
+                    return self.eleven.synth_to_file(text, out_dir, **kwargs)
+                if self.openai is not None:
+                    return self.openai.synth_to_file(text, out_dir, **kwargs)
+                raise
+        # Neutral / default path
+        if self.eleven is not None:
+            return self.eleven.synth_to_file(text, out_dir, **kwargs)
+        if self.openai is not None:
+            return self.openai.synth_to_file(text, out_dir, **kwargs)
+        if self.typecast is not None:
+            return self.typecast.synth_to_file(text, out_dir, **kwargs)
+        raise RuntimeError("No TTS provider available (configure ELEVENLABS_API_KEY / OPENAI_API_KEY / TYPECAST_API_KEY).")
+
+
+from functools import lru_cache
+
 @lru_cache(maxsize=1)
 def get_tts():
     """
-    Hybrid routing:
-      - tone=neutral  -> ElevenLabs
-      - tone=hype/radio -> TypeCast (or fallback to ElevenLabs if TypeCast not configured)
+    Provider selection precedence:
+      - If TTS_PROVIDER is explicitly set to:  openai | elevenlabs | typecast | hybrid
+        honor it (backward compatible).
+      - Otherwise default to 'hybrid' routing (neutral→ElevenLabs, hype/radio→TypeCast),
+        with graceful fallbacks to OpenAI if others are missing.
     """
-    eleven = None
-    typecast = None
-    # Initialize providers (best-effort)
+    provider = (os.getenv("TTS_PROVIDER", "hybrid") or "").lower()
+
+    # Lazy init: try each provider and ignore missing creds
+    eleven = typecast = openai = None
     try:
         eleven = ElevenLabsTTS()
     except Exception:
-        eleven = None
+        pass
     try:
         typecast = TypeCastTTS()
     except Exception:
-        typecast = None
+        pass
+    try:
+        openai = OpenAITTS()
+    except Exception:
+        pass
 
-    class HybridTTS:
-        def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
-            tone = (kwargs.get("tone") or "neutral").lower()
-            # Route by tone
-            if tone in {"hype", "radio"} and typecast is not None:
-                try:
-                    return typecast.synth_to_file(text, out_dir, **kwargs)
-                except Exception:
-                    # Fallback to ElevenLabs if TypeCast fails
-                    if eleven is not None:
-                        return eleven.synth_to_file(text, out_dir, **kwargs)
-                    raise
-            # Default → ElevenLabs
-            if eleven is not None:
-                return eleven.synth_to_file(text, out_dir, **kwargs)
-            # Last resort: TypeCast if ElevenLabs unavailable
-            if typecast is not None:
-                return typecast.synth_to_file(text, out_dir, **kwargs)
-            raise RuntimeError("No TTS provider available")
+    if provider == "openai":
+        if openai is None:
+            raise RuntimeError("OPENAI_API_KEY missing for OpenAI TTS")
+        return openai
+    if provider == "elevenlabs":
+        if eleven is None:
+            raise RuntimeError("ELEVENLABS_API_KEY missing for ElevenLabs TTS")
+        return eleven
+    if provider == "typecast":
+        if typecast is None:
+            raise RuntimeError("TYPECAST_API_KEY missing for TypeCast TTS")
+        return typecast
 
-    return HybridTTS()
+    # Default: hybrid with graceful fallbacks
+    return _HybridTTS(eleven=eleven, typecast=typecast, openai=openai)

--- a/backend/services/tts_providers.py
+++ b/backend/services/tts_providers.py
@@ -4,7 +4,6 @@ from typing import Protocol
 from functools import lru_cache
 import pathlib, uuid, os, requests
 
-
 class TTSClient(Protocol):
     # Accept **kwargs so callers can pass tone/bias without breaking providers.
     def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str: ...
@@ -14,9 +13,9 @@ class TTSClient(Protocol):
 class ElevenLabsTTS:
     # Tunable per-tone settings (light touch so it still sounds natural).
     TONE_SETTINGS = {
-        "hype":   {"stability": 0.45, "similarity_boost": 0.85},
-        "radio":  {"stability": 0.65, "similarity_boost": 0.75},
-        "neutral":{"stability": 0.55, "similarity_boost": 0.80},
+        "hype":    {"stability": 0.45, "similarity_boost": 0.85},
+        "radio":   {"stability": 0.65, "similarity_boost": 0.75},
+        "neutral": {"stability": 0.55, "similarity_boost": 0.80},
     }
 
     def __init__(self):
@@ -105,9 +104,117 @@ class OpenAITTS:
             return str(out)
 
 
+# -------- TypeCast.AI (stub w/ real API support when configured) --------
+class TypeCastTTS:
+    """
+    When TYPECAST_API_KEY is set, call TypeCast API.
+    If not set, gracefully fallback to ElevenLabs (so you can test the flow today).
+    Env:
+      - TYPECAST_API_KEY
+      - TYPECAST_BASE_URL (default: https://api.typecast.ai)
+      - TYPECAST_DEFAULT_VOICE
+      - TYPECAST_VOICE_MAP (JSON: {"hype|neutral": "voice_id", "radio|neutral": "voice_id", ...})
+    """
+    def __init__(self):
+        import json
+        self.key = (os.getenv("TYPECAST_API_KEY") or "").strip()
+        self.base = (os.getenv("TYPECAST_BASE_URL", "https://api.typecast.ai") or "").rstrip("/")
+        self.voice_default = os.getenv("TYPECAST_DEFAULT_VOICE", "typecast_default")
+        try:
+            self.voice_map = json.loads(os.getenv("TYPECAST_VOICE_MAP", "{}"))
+        except Exception:
+            self.voice_map = {}
+        # Prepare ElevenLabs fallback
+        self._fallback_eleven: ElevenLabsTTS | None = None
+        try:
+            self._fallback_eleven = ElevenLabsTTS()
+        except Exception:
+            self._fallback_eleven = None
+
+    def _pick_voice(self, tone: str | None, bias: str | None) -> str:
+        key = f"{(tone or 'neutral').lower()}|{(bias or 'neutral').lower()}"
+        return self.voice_map.get(key, self.voice_default)
+
+    def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
+        # If no API key, fallback to ElevenLabs (keeps your pipeline working)
+        if not self.key:
+            if self._fallback_eleven:
+                return self._fallback_eleven.synth_to_file(text, out_dir, **kwargs)
+            raise RuntimeError("TypeCast not configured and ElevenLabs fallback unavailable")
+
+        out_dir = pathlib.Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / f"tts_{uuid.uuid4().hex}.mp3"
+
+        voice_id = self._pick_voice(kwargs.get("tone"), kwargs.get("bias"))
+        url = f"{self.base}/v1/tts"
+        headers = {"Authorization": f"Bearer {self.key}", "Content-Type": "application/json"}
+        payload = {
+            "voice_id": voice_id,
+            "text": text,
+            # Hint: you can extend with model/emotion/pitch/tempo when you have exact API spec.
+            "metadata": {"tone": kwargs.get("tone"), "bias": kwargs.get("bias")},
+        }
+
+        r = requests.post(url, headers=headers, json=payload, timeout=60)
+        if r.status_code >= 400:
+            raise RuntimeError(f"TypeCast {r.status_code}: {r.text[:200]}")
+
+        # If TypeCast returns JSON with a URL, download; else assume audio bytes.
+        ct = r.headers.get("content-type", "")
+        if "application/json" in ct:
+            data = r.json()
+            audio_url = data.get("audio_url")
+            if not audio_url:
+                raise RuntimeError("TypeCast: no audio_url in response")
+            r2 = requests.get(audio_url, timeout=120)
+            if r2.status_code >= 400:
+                raise RuntimeError(f"TypeCast download {r2.status_code}")
+            out.write_bytes(r2.content)
+        else:
+            out.write_bytes(r.content)
+
+        return str(out)
+
+
+# -------- Hybrid router --------
 @lru_cache(maxsize=1)
 def get_tts():
-    provider = (os.getenv("TTS_PROVIDER", "elevenlabs") or "").lower()
-    if provider == "openai":
-        return OpenAITTS()
-    return ElevenLabsTTS()
+    """
+    Hybrid routing:
+      - tone=neutral  -> ElevenLabs
+      - tone=hype/radio -> TypeCast (or fallback to ElevenLabs if TypeCast not configured)
+    """
+    eleven = None
+    typecast = None
+    # Initialize providers (best-effort)
+    try:
+        eleven = ElevenLabsTTS()
+    except Exception:
+        eleven = None
+    try:
+        typecast = TypeCastTTS()
+    except Exception:
+        typecast = None
+
+    class HybridTTS:
+        def synth_to_file(self, text: str, out_dir: str | pathlib.Path, **kwargs) -> str:
+            tone = (kwargs.get("tone") or "neutral").lower()
+            # Route by tone
+            if tone in {"hype", "radio"} and typecast is not None:
+                try:
+                    return typecast.synth_to_file(text, out_dir, **kwargs)
+                except Exception:
+                    # Fallback to ElevenLabs if TypeCast fails
+                    if eleven is not None:
+                        return eleven.synth_to_file(text, out_dir, **kwargs)
+                    raise
+            # Default → ElevenLabs
+            if eleven is not None:
+                return eleven.synth_to_file(text, out_dir, **kwargs)
+            # Last resort: TypeCast if ElevenLabs unavailable
+            if typecast is not None:
+                return typecast.synth_to_file(text, out_dir, **kwargs)
+            raise RuntimeError("No TTS provider available")
+
+    return HybridTTS()

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -50,7 +50,6 @@ export async function runOcrVideo(file, { viz = false, dx = 0, dy = 0, t = 0.1 }
 }
 
 // ---- One-shot pipeline (recommended) ----
-// Upload *only* a video; backend does OCR → LLM → TTS → (optional) mux.
 export async function runCommentaryFromVideo(
   file,
   {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -50,6 +50,7 @@ export async function runOcrVideo(file, { viz = false, dx = 0, dy = 0, t = 0.1 }
 }
 
 // ---- One-shot pipeline (recommended) ----
+// Upload *only* a video; backend does OCR → LLM → TTS → (optional) mux.
 export async function runCommentaryFromVideo(
   file,
   {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,41 +1,109 @@
 // frontend/src/lib/api.js
+// Centralized API helpers for Mr. TAI frontend
+
+// Base URL (no trailing slash)
 const RAW_API_BASE = import.meta?.env?.VITE_API_BASE ?? "http://localhost:8000";
-// trim any trailing slashes
 export const API_BASE = RAW_API_BASE.replace(/\/+$/, "");
 
-export async function getHealth() {
-  const res = await fetch(`${API_BASE}/health`);
-  if (!res.ok) throw new Error(`Health check failed: ${res.status}`);
-  return res.json();
+// ---- Tone / Bias defaults from env ----
+export const DEFAULT_TONE = import.meta?.env?.VITE_TONE_DEFAULT ?? "neutral";
+export const DEFAULT_BIAS = import.meta?.env?.VITE_BIAS_DEFAULT ?? "neutral";
+
+// ---- Utilities ----
+function toUrl(path) {
+  return `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
 }
 
-export async function uploadFile(file) {
-  const form = new FormData();
-  form.append("file", file);
-
-  const res = await fetch(`${API_BASE}/upload`, {
-    method: "POST",
-    body: form,
-  });
-  if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
-  return res.json();
-}
-
-export async function analyzeCommentate({ file, tone = "play-by-play", audioOnly = false, extra = {} }) {
-  const API_BASE = import.meta?.env?.VITE_API_BASE?.replace(/\/+$/, "") || "http://127.0.0.1:8000";
-  const form = new FormData();
-  if (file) form.append("file", file);
-  form.append("tone", tone);
-  form.append("audio_only", String(audioOnly));
-  // optional extras (home_team, score, etc.)
-  for (const [k, v] of Object.entries(extra)) {
-    if (v != null && v !== "") form.append(k, v);
-  }
-
-  const res = await fetch(`${API_BASE}/analyze_commentate`, { method: "POST", body: form });
+async function httpJson(url, init = {}) {
+  const res = await fetch(url, init);
   if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`analyze_commentate failed: ${res.status} ${text}`);
+    const msg = await res.text().catch(() => "");
+    throw new Error(`${init.method || "GET"} ${url} failed: ${res.status} ${msg}`);
   }
   return res.json();
+}
+
+// ---- Health ----
+export async function getHealth() {
+  return httpJson(toUrl("/health"));
+}
+
+// ---- OCR (optional helpers for debugging/manual use) ----
+export async function runOcrImage(file, { viz = false, debug = false, dx = 0, dy = 0 } = {}) {
+  const fd = new FormData();
+  fd.append("image", file);
+  fd.append("viz", String(viz));
+  fd.append("debug", String(debug));
+  fd.append("dx", String(dx));
+  fd.append("dy", String(dy));
+  return httpJson(toUrl("/ocr/image"), { method: "POST", body: fd });
+}
+
+export async function runOcrVideo(file, { viz = false, dx = 0, dy = 0, t = 0.1 } = {}) {
+  const fd = new FormData();
+  fd.append("video", file);
+  fd.append("viz", String(viz));
+  fd.append("dx", String(dx));
+  fd.append("dy", String(dy));
+  fd.append("t", String(t));
+  return httpJson(toUrl("/ocr/video"), { method: "POST", body: fd });
+}
+
+// ---- One-shot pipeline (recommended) ----
+export async function runCommentaryFromVideo(
+  file,
+  {
+    tone = DEFAULT_TONE,
+    bias = DEFAULT_BIAS,
+    audioOnly = false,
+    viz = false,
+    dx = 0,
+    dy = 0,
+    t = 0.1,
+  } = {}
+) {
+  const fd = new FormData();
+  fd.append("video", file);
+  fd.append("tone", tone);
+  fd.append("bias", bias);
+  fd.append("audio_only", String(audioOnly));
+  fd.append("viz", String(viz));
+  fd.append("dx", String(dx));
+  fd.append("dy", String(dy));
+  fd.append("t", String(t));
+  return httpJson(toUrl("/pipeline/run-commentary-from-video"), { method: "POST", body: fd });
+}
+
+// ---- Legacy: direct analyze endpoint (kept for compatibility) ----
+export async function analyzeCommentate(
+  file,
+  {
+    home_team = null,
+    away_team = null,
+    score = null,
+    quarter = null,
+    clock = null,
+    tone = DEFAULT_TONE,
+    bias = DEFAULT_BIAS,
+    voice = "default",
+    audio_only = false,
+  } = {}
+) {
+  const fd = new FormData();
+  if (file) fd.append("file", file);
+  if (home_team != null) fd.append("home_team", String(home_team));
+  if (away_team != null) fd.append("away_team", String(away_team));
+  if (score != null) fd.append("score", String(score));
+  if (quarter != null) fd.append("quarter", String(quarter));
+  if (clock != null) fd.append("clock", String(clock));
+  fd.append("tone", tone);
+  fd.append("bias", bias);
+  fd.append("voice", voice);
+  fd.append("audio_only", String(audio_only));
+  return httpJson(toUrl("/analyze_commentate"), { method: "POST", body: fd });
+}
+
+// ---- Helpers for building absolute static URLs in the UI ----
+export function staticUrl(pathOrNull) {
+  return pathOrNull ? toUrl(pathOrNull) : "";
 }

--- a/frontend/src/pages/Commentator.jsx
+++ b/frontend/src/pages/Commentator.jsx
@@ -1,267 +1,105 @@
+// frontend/src/pages/Commentator.jsx
 import React, { useState } from "react";
-import { API_BASE } from "../lib/api";
+import { API_BASE, runCommentaryFromVideo, DEFAULT_TONE, DEFAULT_BIAS } from "../lib/api";
 
 export default function Commentator() {
   const [file, setFile] = useState(null);
-  const [form, setForm] = useState({
-    home_team: "USC",
-    away_team: "UCLA",
-    score: "21-24",
-    quarter: "Q4",
-    clock: "0:42",
-    tone: "hype",
-    bias: "neutral",
-    voice: "default",
-  });
-  const [audioOnly, setAudioOnly] = useState(false);
+  const [tone, setTone] = useState(String(DEFAULT_TONE || "neutral"));   // neutral | hype | radio
+  const [bias, setBias] = useState(String(DEFAULT_BIAS || "neutral"));   // neutral | home | away
   const [loading, setLoading] = useState(false);
   const [resp, setResp] = useState(null);
-  const [error, setError] = useState(null);
+  const [err, setErr] = useState("");
 
+  const canRun = !!file;
   const staticUrl = (u) => (u ? `${API_BASE}${u}` : "");
 
-  async function onSubmit() {
-    if (!file && !audioOnly) {
-      return setError("Select a clip or enable “Audio only”.");
-    }
-    setError(null);
-    setLoading(true);
-    setResp(null);
-
-    const body = new FormData();
-    if (file) body.append("file", file);
-    Object.entries(form).forEach(([k, v]) => body.append(k, v));
-    body.append("audio_only", String(audioOnly));
-
+  async function onRun() {
+    if (!file) return;
+    setErr(""); setResp(null); setLoading(true);
     try {
-      const r = await fetch(`${API_BASE}/analyze_commentate`, { method: "POST", body });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const j = await r.json();
-      setResp(j);
+      const data = await runCommentaryFromVideo(file, { tone, bias, audioOnly: false });
+      setResp(data);
     } catch (e) {
-      setError(e?.message || "Request failed");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function onDemoMode() {
-    setError(null);
-    setLoading(true);
-    setResp(null);
-    try {
-      const r = await fetch(`${API_BASE}/demo/artifacts`);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const j = await r.json();
-      setResp({
-        id: "demo",
-        text: j.text || "Demo commentary",
-        audio_url: j.audio_url || null,
-        video_url: j.video_url || null,
-        meta: { duration_s: 0, errors: null, usedManualContext: false },
-      });
-    } catch (e) {
-      setError(e?.message || "Failed to load demo artifacts");
+      setErr(String(e.message || e));
     } finally {
       setLoading(false);
     }
   }
 
   function onReset() {
-    setFile(null);
-    setResp(null);
-    setError(null);
-    setAudioOnly(false);
-    setForm({
-      home_team: "USC",
-      away_team: "UCLA",
-      score: "21-24",
-      quarter: "Q4",
-      clock: "0:42",
-      tone: "hype",
-      bias: "neutral",
-      voice: "default",
-    });
+    setFile(null); setResp(null); setErr("");
   }
 
-  const canAnalyze = !!file || audioOnly;
-  const labelStyle = { display: "grid", gap: 6, fontSize: 12, color: "#374151", lineHeight: 1.25 };
-  const inputStyle = { padding: 8, border: "1px solid #d1d5db", borderRadius: 6 };
-
   return (
-    <div style={{ maxWidth: 720, margin: "40px auto", padding: 16 }}>
-      <h1>Mr. TAI — Madden Commentator (MVP)</h1>
+    <div style={{ maxWidth: 840, margin: "40px auto", padding: 16 }}>
+      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 12 }}>Mr. TAI • One-Shot Commentary</h1>
 
-      <div style={{ display: "grid", gap: 12, marginTop: 16 }}>
-        <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
-          <label style={{ ...labelStyle, margin: 0 }}>
-            <span>Clip (video/audio)</span>
-            <input
-              type="file"
-              accept="video/mp4,video/*,audio/*"
-              onChange={(e) => setFile(e.target.files?.[0] || null)}
-              disabled={loading}
-            />
-          </label>
+      <div style={{ display: "grid", gap: 10 }}>
+        <input
+          type="file"
+          accept="video/*"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          disabled={loading}
+        />
 
-          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <input
-              type="checkbox"
-              checked={audioOnly}
-              onChange={(e) => setAudioOnly(e.target.checked)}
-              disabled={loading}
-            />
-            <span>Audio only (no clip)</span>
-          </label>
-        </div>
-
-        {/* Two-column, one-field-per-cell to avoid vertical offset */}
-        <div style={{ display: "grid", gap: 10, gridTemplateColumns: "1fr 1fr", alignItems: "end" }}>
-          <label style={labelStyle}>
-            <span>Home Team</span>
-            <input
-              style={inputStyle}
-              value={form.home_team}
-              onChange={(e) => setForm({ ...form, home_team: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Away Team</span>
-            <input
-              style={inputStyle}
-              value={form.away_team}
-              onChange={(e) => setForm({ ...form, away_team: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Score</span>
-            <input
-              style={inputStyle}
-              placeholder="e.g., 21-24"
-              value={form.score}
-              onChange={(e) => setForm({ ...form, score: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Quarter</span>
-            <input
-              style={inputStyle}
-              placeholder="Q1–Q4/OT"
-              value={form.quarter}
-              onChange={(e) => setForm({ ...form, quarter: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Clock</span>
-            <input
-              style={inputStyle}
-              placeholder="e.g., 0:42"
-              value={form.clock}
-              onChange={(e) => setForm({ ...form, clock: e.target.value })}
-              disabled={loading}
-            />
-          </label>
-
-          <label style={labelStyle}>
-            <span>Tone</span>
-            <select
-              style={inputStyle}
-              value={form.tone}
-              onChange={(e) => setForm({ ...form, tone: e.target.value })}
-              disabled={loading}
-            >
-              <option value="hype">hype</option>
-              <option value="neutral">neutral</option>
-              <option value="radio">radio</option>
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+          <label>
+            Tone:&nbsp;
+            <select value={tone} onChange={(e) => setTone(e.target.value)} disabled={loading}>
+              <option value="neutral">neutral (ElevenLabs)</option>
+              <option value="hype">hype (TypeCast)</option>
+              <option value="radio">radio (TypeCast)</option>
             </select>
           </label>
-
-          {/* spacer to keep symmetry */}
-          <div aria-hidden="true" />
-
-          <label style={labelStyle}>
-            <span>Bias (POV)</span>
-            <select
-              style={inputStyle}
-              value={form.bias}
-              onChange={(e) => setForm({ ...form, bias: e.target.value })}
-              disabled={loading}
-              title="Commentator POV bias"
-            >
+          <label>
+            Bias:&nbsp;
+            <select value={bias} onChange={(e) => setBias(e.target.value)} disabled={loading}>
               <option value="neutral">neutral</option>
               <option value="home">home</option>
               <option value="away">away</option>
             </select>
           </label>
-        </div>
 
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <button onClick={onSubmit} disabled={loading || !canAnalyze}>
-            {loading ? "Working…" : "Analyze & Commentate"}
+          <button onClick={onRun} disabled={!canRun || loading} style={{ padding: "8px 12px" }}>
+            {loading ? "Running…" : "Run Commentary"}
           </button>
-          <button onClick={onDemoMode} disabled={loading}>
-            Demo Mode (prefilled backup)
-          </button>
-          <button onClick={onReset} disabled={loading}>
+          <button onClick={onReset} disabled={loading} style={{ padding: "8px 12px" }}>
             Reset
           </button>
-          {!canAnalyze && (
-            <span style={{ marginLeft: 8, color: "#b45309", fontSize: 12 }}>
-              Select a clip or enable “Audio only”.
-            </span>
-          )}
         </div>
+      </div>
 
-        {error && <div style={{ color: "crimson" }}>{error}</div>}
+      {!canRun && <div style={{ marginTop: 8, color: "#b45309", fontSize: 12 }}>Select a video to continue.</div>}
+      {err && <div style={{ marginTop: 12, color: "crimson" }}>{err}</div>}
 
-        {resp && (
-          <div style={{ marginTop: 16, display: "grid", gap: 12 }}>
-            <div>
-              <h3>Commentary Text</h3>
-              <p style={{ whiteSpace: "pre-wrap" }}>{resp.text}</p>
-            </div>
+      {resp && (
+        <div style={{ marginTop: 20, display: "grid", gap: 16 }}>
+          <div style={{ padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+            <div style={{ fontWeight: 600, marginBottom: 6 }}>Commentary Text</div>
+            <pre style={{ whiteSpace: "pre-wrap", margin: 0 }}>{resp.text}</pre>
+          </div>
 
+          <div style={{ display: "grid", gap: 16 }}>
             {resp.audio_url && (
-              <div>
-                <h3>Audio</h3>
+              <div style={{ padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Audio</div>
                 <audio controls src={staticUrl(resp.audio_url)} />
-                <div><a href={staticUrl(resp.audio_url)} download>Download audio</a></div>
               </div>
             )}
-
             {resp.video_url && (
-              <div>
-                <h3>Dubbed Video</h3>
-                <video
-                  controls
-                  src={staticUrl(resp.video_url)}
-                  style={{ width: "100%", borderRadius: 8 }}
-                />
-                <div><a href={staticUrl(resp.video_url)} download>Download video</a></div>
+              <div style={{ padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Dubbed Video</div>
+                <video controls width={640} src={staticUrl(resp.video_url)} />
               </div>
-            )}
-
-            <small>
-              Latency: {resp.meta?.duration_s != null ? resp.meta.duration_s.toFixed?.(3) : "—"}s
-              {resp.meta?.usedManualContext ? " • manual context" : ""}
-              {resp.meta?.audio_only ? " • audio-only" : ""}
-              {resp.meta?.prompt_tone ? ` • tone: ${resp.meta.prompt_tone}` : ""}
-              {resp.meta?.prompt_bias ? ` • bias: ${resp.meta.prompt_bias}` : ""}
-            </small>
-            {resp.meta?.errors && (
-              <pre style={{ color: "crimson" }}>{JSON.stringify(resp.meta.errors, null, 2)}</pre>
             )}
           </div>
-        )}
-      </div>
+
+          <div style={{ padding: 12, border: "1px solid #eee", borderRadius: 8 }}>
+            <div style={{ fontWeight: 600, marginBottom: 6 }}>Meta</div>
+            <pre style={{ margin: 0, fontSize: 12 }}>{JSON.stringify(resp.meta, null, 2)}</pre>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Title: feat|fix|chore(scope): hybrid TTS routing (ElevenLabs+TypeCast), env defaults, tone/bias UI, API cleanup

## Summary
Backend (tts_providers.py)
- Add TypeCastTTS (stub with real API path if configured).
- Introduce Hybrid router in get_tts():
tone=neutral → ElevenLabs
tone=hype/radio → TypeCast (falls back to ElevenLabs if TypeCast not configured)
- Keeps tone/bias kwargs threaded end-to-end.
Frontend (api.js)
- Convert to named exports only (fixes “Identifier 'getHealth' has already been declared”).
- Add env-based defaults: DEFAULT_TONE / DEFAULT_BIAS via VITE_TONE_DEFAULT / VITE_BIAS_DEFAULT.
- runCommentaryFromVideo now defaults to env-driven tone/bias.
Frontend (Commentator.jsx)
- Add tone & bias dropdowns (default from env).
- Post only video + tone/bias to /pipeline/run-commentary-from-video.
- Preserve results panel (text, audio_url, video_url, meta).

## Testing
- Backend
# ElevenLabs-only (no TypeCast keys yet)
export TTS_PROVIDER=hybrid
export ELEVENLABS_API_KEY=...    # in .env.local
export ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
uvicorn main:app --reload --port 8000
Verify with curl:
curl -s -F "video=@/path/clip.mp4" -F "tone=neutral" -F "bias=neutral" \
  http://localhost:8000/pipeline/run-commentary-from-video | jq .
- Frontend
cd frontend
echo "VITE_API_BASE=http://localhost:8000" > .env.local
echo "VITE_TONE_DEFAULT=neutral" >> .env.local
echo "VITE_BIAS_DEFAULT=neutral" >> .env.local
npm i && npm run dev
# open /commentator, upload a small clip, switch tone between neutral/hype/radio
Expected: page shows tone/bias dropdowns; “Run Commentary” returns text + audio_url (+ video_url if muxed).

- (Optional) TypeCast test
Add to .env.local:
TYPECAST_API_KEY=sk-typecast-...
TYPECAST_BASE_URL=https://api.typecast.ai
TYPECAST_DEFAULT_VOICE=typecast_default
TYPECAST_VOICE_MAP={"hype|neutral":"voice_typecast_hype","radio|neutral":"voice_typecast_radio"}
Restart backend → set tone=hype/radio → audio should be synthesized via TypeCast.

## Next Steps
- [ ] Replace TypeCast stub with exact endpoint/params (emotion/model/pitch/tempo) + polling if required.
- [ ] Expose a backend route to list voices from TypeCast and populate a dynamic selector in the UI.
- [ ] Persist last-used tone/bias in localStorage for better UX.