### PR TITLE
feat(paddleocr): integrate PaddleOCR for faster scoreboard parsing and improve frontend voice labeling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ runs/
 *.pth
 *.onnx
 *.dylib
+
+madden_profile.json

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,53 +1,80 @@
-annotated-types==0.7.0
-anyio==4.10.0
-av==15.0.0
-certifi==2025.8.3
-charset-normalizer==3.4.3
-click==8.2.1
-coloredlogs==15.0.1
-ctranslate2==4.6.0
+# -------------------------------
+# Core framework
+# -------------------------------
 fastapi==0.116.1
-faster-whisper==1.2.0
-ffmpeg-python==0.2.0
-filelock==3.19.1
-flatbuffers==25.2.10
-fsspec==2025.7.0
-future==1.0.0
-h11==0.16.0
-hf-xet==1.1.8
-huggingface-hub==0.34.4
-humanfriendly==10.0
-idna==3.10
-mpmath==1.3.0
-numpy==2.3.2
-onnxruntime==1.22.1
-packaging==25.0
-protobuf==6.32.0
+uvicorn==0.35.0
+starlette==0.47.2
+python-multipart==0.0.20
+python-dotenv==1.1.1
 pydantic==2.11.7
 pydantic_core==2.33.2
-python-dotenv==1.1.1
-python-multipart==0.0.20
-PyYAML==6.0.2
-requests==2.32.5
-sniffio==1.3.1
-starlette==0.47.2
-sympy==1.14.0
-tokenizers==0.21.4
-tqdm==4.67.1
+anyio==4.10.0
 typing-inspection==0.4.1
 typing_extensions==4.14.1
-urllib3==2.5.0
-uvicorn==0.35.0
+
+# -------------------------------
+# Audio / Video processing
+# -------------------------------
+ffmpeg-python==0.2.0
+av==15.0.0
+faster-whisper==1.2.0
+ctranslate2==4.6.0
+onnxruntime==1.22.1
+numpy==2.3.2
 pillow>=10.3.0
 opencv-python-headless>=4.10.0.84
+
+# -------------------------------
+# OCR (legacy + helpers)
+# -------------------------------
 pytesseract>=0.3.10
 rapidfuzz>=3.9.5
 
-# Dev tools
+# -------------------------------
+# PaddleOCR stack
+# NOTE: Install PaddlePaddle separately on Apple Silicon:
+#   pip install --upgrade "paddlepaddle==2.6.1" --extra-index-url https://www.paddlepaddle.org.cn/whl/macos/mps
+# Then install paddleocr (no extra heavy PDF deps needed for our use):
+# -------------------------------
+paddleocr==2.7.0.3
+shapely>=2.0.4
+pyclipper>=1.3.0.post5
+scikit-image>=0.24.0
+fire>=0.6.0
+python-Levenshtein>=0.26.0
+lmdb>=1.4.1
+
+# -------------------------------
+# Logging & utilities
+# -------------------------------
+coloredlogs==15.0.1
+humanfriendly==10.0
+tqdm==4.67.1
+requests==2.32.5
+filelock==3.19.1
+packaging==25.0
+flatbuffers==25.2.10
+future==1.0.0
+certifi==2025.8.3
+charset-normalizer==3.4.3
+idna==3.10
+urllib3==2.5.0
+protobuf==6.32.0
+PyYAML==6.0.2
+fsspec==2025.7.0
+huggingface-hub==0.34.4
+hf-xet==1.1.8
+
+# -------------------------------
+# Text-to-speech and helpers
+# -------------------------------
+pyttsx3
+aiofiles
+
+# -------------------------------
+# Dev / Formatting / Testing
+# -------------------------------
 black
 ruff
 pytest
 pre-commit
-
-pyttsx3
-aiofiles

--- a/backend/routers/pipeline_api.py
+++ b/backend/routers/pipeline_api.py
@@ -1,12 +1,12 @@
 # backend/routers/pipeline_api.py
 from __future__ import annotations
-from fastapi import APIRouter, UploadFile, File, HTTPException, Form
+from fastapi import APIRouter, UploadFile, File, HTTPException, Form, Query
 from pydantic import BaseModel
 from typing import Optional, Iterable, Dict, Any, List
 from pathlib import Path, PurePath
 import shutil, os, uuid, subprocess, shlex
 
-from backend.services.ocr_from_video import extract_scoreboard_from_video
+from backend.services.ocr_paddle import extract_scoreboard_from_video_paddle
 from backend.services.context_from_ocr import ocr_to_commentary_context
 from backend.services.llm_providers import get_llm
 from backend.services.tts_providers import get_tts
@@ -57,7 +57,6 @@ def _safe_save_upload(upload: UploadFile, allow_exts: Iterable[str]) -> Path:
             pass
     return dest
 
-# ---------- Models ----------
 class CommentaryPrepResponse(BaseModel):
     context: Dict[str, Any]
     ocr: Dict[str, Any]
@@ -70,8 +69,7 @@ class CommentaryRunResponse(BaseModel):
     video_url: Optional[str] = None
     meta: Dict[str, Any]
 
-# ---------- Voice catalog & mapping ----------
-# Your verified 6 voices
+# ---------- Voice catalog & mapping (unchanged from your working version) ----------
 VOICE_CATALOG: List[Dict[str, Any]] = [
     {"id": "tc_673eb45cdc1073aef51e6b90", "name": "Dean",    "gender": "male",   "emotions": ["tonedown", "normal", "toneup"]},
     {"id": "tc_6412c42d733f60ab8ad369a9", "name": "Caitlyn", "gender": "female", "emotions": ["normal"]},
@@ -81,164 +79,40 @@ VOICE_CATALOG: List[Dict[str, Any]] = [
     {"id": "tc_630494521f5003bebbfdafef", "name": "Rachel",  "gender": "female", "emotions": ["normal", "toneup", "happy"]},
 ]
 
-# Preferred voice per (tone,gender)
 VOICE_BY_TONE_GENDER = {
-    "neutral": {"male": "tc_673eb45cdc1073aef51e6b90", "female": "tc_6412c42d733f60ab8ad369a9"},  # Dean / Caitlyn
-    "radio":   {"male": "tc_6837b58f80ceeb17115bb771", "female": "tc_684a5a7ba2ce934624b59c6e"},  # Walter / Nia
-    "hype":    {"male": "tc_623145940c2c1ff30c30f3a9", "female": "tc_630494521f5003bebbfdafef"},  # Matthew / Rachel
+    "neutral": {"male": "tc_673eb45cdc1073aef51e6b90", "female": "tc_6412c42d733f60ab8ad369a9"},
+    "radio":   {"male": "tc_6837b58f80ceeb17115bb771", "female": "tc_684a5a7ba2ce934624b59c6e"},
+    "hype":    {"male": "tc_623145940c2c1ff30c30f3a9", "female": "tc_630494521f5003bebbfdafef"},
 }
 
-# Emotion preference per tone (used for previews & fallback)
 PREFERRED_BY_TONE = {
     "neutral": ["normal"],
     "radio":   ["tonedown", "normal", "tonemid"],
     "hype":    ["shout", "toneup", "happy", "normal"],
 }
 
-# Explicit emotion hint per (tone,gender) for run pipeline (matches supports)
-EMOTION_BY_TONE_GENDER = {
-    "neutral": {"male": "normal",  "female": "normal"},
-    "radio":   {"male": "normal",  "female": "tonedown"},  # Walter only normal; Nia supports tonedown
-    "hype":    {"male": "shout",   "female": "toneup"},    # Matthew shout; Rachel toneup
-}
-
 def _pick_emotion(tone: str, supported: List[str]) -> str:
     for e in PREFERRED_BY_TONE.get(tone, ["normal"]):
-        if e in supported:
-            return e
+        if e in supported: return e
     return "normal"
 
-# ---------- Helpers ----------
 def _to_wav_from_mp3(mp3_path: Path) -> Path:
-    """Convert MP3 -> 16k mono WAV for muxing where needed."""
     wav_path = mp3_path.with_suffix(".wav")
     cmd = f'ffmpeg -y -i {shlex.quote(str(mp3_path))} -ac 1 -ar 16000 {shlex.quote(str(wav_path))}'
     subprocess.run(shlex.split(cmd), check=True)
     return wav_path
 
-# ---------- Endpoints ----------
-@router.post("/commentary-from-video", response_model=CommentaryPrepResponse)
-def commentary_from_video(
-    video: UploadFile = File(...),
-    viz: bool = Form(False),
-    dx: int = Form(0),
-    dy: int = Form(0),
-    t: float = Form(0.10),
-):
-    dest = _safe_save_upload(video, VIDEO_EXTS)
-    keep_uploads = os.getenv("KEEP_UPLOADS", "0") == "1"
-    try:
-        ocr = extract_scoreboard_from_video(str(dest), viz=viz, dx=dx, dy=dy, t=t)
-        ctx = ocr_to_commentary_context(ocr)
-        return CommentaryPrepResponse(context=ctx, ocr=ocr, used_stub=bool(ocr.get("used_stub", False)))
-    finally:
-        if not keep_uploads:
-            try:
-                dest.unlink(missing_ok=True)
-            except Exception:
-                pass
-
-@router.post("/run-commentary-from-video", response_model=CommentaryRunResponse)
-def run_commentary_from_video(
-    video: UploadFile = File(...),
-    viz: bool = Form(False),
-    dx: int = Form(0),
-    dy: int = Form(0),
-    t: float = Form(0.10),
-    tone: Optional[str] = Form(None),
-    bias: Optional[str] = Form(None),
-    gender: Optional[str] = Form(None),
-    audio_only: bool = Form(False),
-):
-    """
-    upload video -> OCR -> build context -> LLM -> TTS -> (optional) mux
-    """
-    dest = _safe_save_upload(video, VIDEO_EXTS)
-    keep_uploads = os.getenv("KEEP_UPLOADS", "0") == "1"
-    run_id = f"run_{uuid.uuid4().hex[:10]}"
-
-    try:
-        # 1) OCR -> context
-        ocr = extract_scoreboard_from_video(str(dest), viz=viz, dx=dx, dy=dy, t=t)
-        ctx = ocr_to_commentary_context(ocr)
-        if tone: ctx["tone"] = tone
-        if bias: ctx["bias"] = bias
-
-        tone_val = normalize_tone(str(ctx.get("tone", "neutral")))
-        if tone_val not in ("neutral", "radio", "hype"):
-            tone_val = "neutral"
-        gender_val = (gender or "male").strip().lower()
-        if gender_val not in ("male", "female"):
-            gender_val = "male"
-
-        # 2) LLM
-        llm = get_llm()
-        prompt = build_llm_prompt(ctx)
-        text = llm.generate(
-            prompt,
-            meta={"tone": tone_val, "bias": str(ctx.get("bias", "neutral")).lower(), "gender": gender_val},
-        )
-
-        # 3) TTS
-        tts = get_tts()
-        voice_id = VOICE_BY_TONE_GENDER.get(tone_val, {}).get(gender_val)
-        emotion = EMOTION_BY_TONE_GENDER.get(tone_val, {}).get(gender_val, "normal")
-        audio_mp3_path = tts.synth_to_file(
-            text, DATA_DIR / "uploads" / "tts",
-            tone=tone_val,
-            bias=str(ctx.get("bias", "neutral")),
-            voice_id=voice_id,
-            emotion_preset=emotion,
-        )  # type: ignore[call-arg]
-        audio_mp3 = Path(audio_mp3_path)
-
-        # 4) Mux (if not audio-only)
-        video_out: Optional[Path] = None
-        if not audio_only and audio_mp3.exists():
-            audio_wav = _to_wav_from_mp3(audio_mp3)
-            vid_out_path = mux_audio_video(str(dest), str(audio_wav))
-            video_out = Path(vid_out_path) if isinstance(vid_out_path, str) else vid_out_path
-
-        # 5) Response
-        return CommentaryRunResponse(
-            id=run_id,
-            text=text,
-            audio_url=(to_static_url(audio_mp3) if (audio_mp3 and audio_mp3.exists()) else None),
-            video_url=(to_static_url(video_out) if video_out else None),
-            meta={
-                "usedManualContext": False,
-                "provider": {"llm": type(llm).__name__, "tts": type(tts).__name__},
-                "prompt_tone": tone_val,
-                "prompt_bias": str(ctx.get("bias", "neutral")).lower(),
-                "gender": gender_val,
-                "audio_only": audio_only,
-                "ocr_used_stub": bool(ocr.get("used_stub", False)),
-                "ocr_raw": ocr,
-            },
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Pipeline error: {e}")
-    finally:
-        if not keep_uploads:
-            try:
-                dest.unlink(missing_ok=True)
-            except Exception:
-                pass
-
-# ---------- Voice options (for audition UI) ----------
+# ---------- Voice option & preview (for UI) ----------
 @router.get("/voice-options")
-def voice_options(tone: Optional[str] = None, gender: Optional[str] = None):
+def voice_options(
+    tone: Optional[str] = Query(None),
+    gender: Optional[str] = Query(None),
+):
     tone_val = normalize_tone(str(tone or "neutral"))
     items = [v for v in VOICE_CATALOG if (not gender or v["gender"] == gender)]
-    out = []
-    for v in items:
-        out.append({
-            **v,
-            "suggested_emotion": _pick_emotion(tone_val, v["emotions"]),
-        })
+    out = [{"suggested_emotion": _pick_emotion(tone_val, v["emotions"]), **v} for v in items]
     return {"voices": out, "tone": tone_val, "gender": (gender or "").lower() or None}
 
-# ---------- Voice preview (audition any voice) ----------
 @router.post("/voice-preview")
 def voice_preview(
     tone: Optional[str] = Form("neutral"),
@@ -253,7 +127,6 @@ def voice_preview(
     if gender_val not in ("male", "female"):
         gender_val = "male"
 
-    # If not explicitly provided, use the mapped voice and a best-fit emotion
     if not voice_id:
         voice_id = VOICE_BY_TONE_GENDER.get(tone_val, {}).get(gender_val)
     if not voice_id:
@@ -272,9 +145,135 @@ def voice_preview(
         bias=str(bias or "neutral"),
         voice_id=voice_id,
         emotion_preset=emotion_preset,
-    )  # type: ignore[call-arg]
+    )  # type: ignore[arg-type]
 
     return {
         "audio_url": to_static_url(Path(out_path)),
         "meta": {"tone": tone_val, "gender": gender_val, "voice_id": voice_id, "emotion": emotion_preset},
     }
+
+# ---------- Prep ----------
+@router.post("/commentary-from-video", response_model=CommentaryPrepResponse)
+def commentary_from_video(
+    video: UploadFile = File(...),
+    viz: bool = Form(False),
+    dx: int = Form(0),  # kept for compatibility
+    dy: int = Form(0),
+    t: float = Form(0.10),
+    debug_prompt: Optional[int] = Query(None),
+):
+    dest = _safe_save_upload(video, VIDEO_EXTS)
+    keep_uploads = os.getenv("KEEP_UPLOADS", "0") == "1"
+    try:
+        ocr = extract_scoreboard_from_video_paddle(str(dest), t=t, attempts=3, viz=viz)
+        ctx = ocr_to_commentary_context(ocr)
+        return CommentaryPrepResponse(context=ctx, ocr=ocr, used_stub=bool(ocr.get("used_stub", False)))
+    finally:
+        if not keep_uploads:
+            try: dest.unlink(missing_ok=True)
+            except Exception: pass
+
+# ---------- Run ----------
+@router.post("/run-commentary-from-video", response_model=CommentaryRunResponse)
+def run_commentary_from_video(
+    video: UploadFile = File(...),
+    viz: bool = Form(False),
+    dx: int = Form(0),
+    dy: int = Form(0),
+    t: float = Form(0.10),
+    tone: Optional[str] = Form(None),
+    bias: Optional[str] = Form(None),
+    gender: Optional[str] = Form(None),
+    audio_only: bool = Form(False),
+    voice_id: Optional[str] = Form(None),
+    emotion_preset: Optional[str] = Form(None),
+    debug_prompt: Optional[int] = Query(None),
+):
+    dest = _safe_save_upload(video, VIDEO_EXTS)
+    keep_uploads = os.getenv("KEEP_UPLOADS", "0") == "1"
+    run_id = f"run_{uuid.uuid4().hex[:10]}"
+
+    try:
+        # 1) OCR via PaddleOCR (with ROI viz if requested)
+        ocr = extract_scoreboard_from_video_paddle(str(dest), t=t, attempts=3, viz=viz)
+        ctx = ocr_to_commentary_context(ocr)
+        if tone: ctx["tone"] = tone
+        if bias: ctx["bias"] = bias
+
+        tone_val = normalize_tone(str(ctx.get("tone", "neutral")))
+        gender_val = (gender or "male").strip().lower()
+        if gender_val not in ("male", "female"):
+            gender_val = "male"
+
+        # 2) LLM — build prompt & (optionally) save it
+        llm = get_llm()
+        prompt = build_llm_prompt(ctx)
+
+        # Print to console if DEBUG_PROMPT=1
+        if os.getenv("DEBUG_PROMPT", "0") == "1" or (debug_prompt and int(debug_prompt) == 1):
+            print("\n=== LLM PROMPT (run_id:", run_id, ") ===\n")
+            print(prompt)
+            print("\n=== END PROMPT ===\n")
+            # also save to file
+            out_dir = DATA_DIR / "tmp" / "prompts"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / f"prompt_{run_id}.txt").write_text(prompt, encoding="utf-8")
+
+        text = llm.generate(
+            prompt,
+            meta={"tone": tone_val, "bias": str(ctx.get("bias","neutral")).lower(), "gender": gender_val},
+        )
+
+        # 3) TTS selection
+        if not voice_id:
+            voice_id = VOICE_BY_TONE_GENDER.get(tone_val, {}).get(gender_val)
+        if not voice_id:
+            raise HTTPException(status_code=400, detail=f"No mapped voice for tone={tone_val} gender={gender_val}")
+
+        if not emotion_preset:
+            v = next((v for v in VOICE_CATALOG if v["id"] == voice_id), None)
+            supported = list(v["emotions"]) if v else ["normal"]
+            emotion_preset = _pick_emotion(tone_val, supported)
+
+        tts = get_tts()
+        audio_mp3_path = tts.synth_to_file(
+            text, DATA_DIR / "uploads" / "tts",
+            tone=tone_val, bias=str(ctx.get("bias","neutral")),
+            voice_id=voice_id, emotion_preset=emotion_preset,
+        )  # type: ignore[arg-type]
+        audio_mp3 = Path(audio_mp3_path)
+
+        # 4) Mux (if not audio-only)
+        video_out: Optional[Path] = None
+        if not audio_only and audio_mp3.exists():
+            audio_wav = _to_wav_from_mp3(audio_mp3)
+            vid_out_path = mux_audio_video(str(dest), str(audio_wav))
+            video_out = Path(vid_out_path) if isinstance(vid_out_path, str) else vid_out_path
+
+        return CommentaryRunResponse(
+            id=run_id,
+            text=text,
+            audio_url=(to_static_url(audio_mp3) if (audio_mp3 and audio_mp3.exists()) else None),
+            video_url=(to_static_url(video_out) if video_out else None),
+            meta={
+                "usedManualContext": False,
+                "provider": {"llm": type(llm).__name__, "tts": type(tts).__name__, "ocr": "paddleocr"},
+                "prompt_tone": tone_val,
+                "prompt_bias": str(ctx.get("bias", "neutral")).lower(),
+                "gender": gender_val,
+                "selected_voice_id": voice_id,
+                "selected_emotion": emotion_preset,
+                "audio_only": audio_only,
+                "ocr_used_stub": bool(ocr.get("used_stub", False)),
+                "ocr_raw": ocr,
+                "prompt_file": f"/data/tmp/prompts/prompt_{run_id}.txt" if os.getenv("DEBUG_PROMPT","0")=="1" or (debug_prompt and int(debug_prompt)==1) else None,
+            },
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Pipeline error: {e}")
+    finally:
+        if not keep_uploads:
+            try: dest.unlink(missing_ok=True)
+            except Exception: pass

--- a/backend/services/ocr_paddle.py
+++ b/backend/services/ocr_paddle.py
@@ -1,354 +1,256 @@
 # backend/services/ocr_paddle.py
 from __future__ import annotations
-
-import os
-import shlex
-import subprocess
-import time
-import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
-from collections import Counter
-from threading import Lock
+from typing import Dict, Any, List, Optional, Tuple
+import os, uuid, shlex, subprocess, re, shutil
+from typing import Any, Optional, TYPE_CHECKING
 
-import numpy as np
+try:
+    from paddleocr import PaddleOCR  # runtime import
+except Exception:
+    PaddleOCR = None  # type: ignore[assignment]
 
-# Pillow
+if TYPE_CHECKING:
+    # static type name only visible to the type checker
+    from paddleocr import PaddleOCR as _PaddleOCRType
+else:
+    _PaddleOCRType = Any  # at runtime we don't care
+
 from PIL import Image, ImageDraw
 
-# Optional OpenCV (faster frame grabs if available)
-try:
-    import cv2  # type: ignore
-except Exception:
-    cv2 = None  # fallback to ffmpeg
+# ---------- Config ----------
+DATA_DIR = Path(os.getenv("DATA_DIR", "data"))
+TMP_ROOT = DATA_DIR / "tmp" / "runs"
+TMP_ROOT.mkdir(parents=True, exist_ok=True)
 
-# PaddleOCR (lazy init)
-try:
-    from paddleocr import PaddleOCR  # type: ignore
-except Exception as e:
-    PaddleOCR = None  # type: ignore
-
-
-# ---------- Reference full-frame -> scoreboard crop ----------
-# Reference full-frame: 2047x1155, scoreboard y=[1080,1155)
+# Reference full frame dims & scoreboard strip at bottom (like your old pipeline)
 REF_FRAME_W, REF_FRAME_H = 2047, 1155
-SCOREBAR_BOX = (0, 1080, 2047, 1155)  # (left, top, right, bottom) in reference space
+SCOREBAR_BOX = (0, 1080, 2047, 1155)  # left, top, right, bottom in reference space
 
-# ---------- Your exact pixel ROIs on the scoreboard crop (x0, y0, x1, y1) ----------
-# (Keep these as you tuned them for Madden.)
-SB_ROIS_PX: Dict[str, Tuple[int, int, int, int]] = {
-    "away_team":  (500,  0, 600,  50),
-    "home_team":  (900,  0, 1000, 50),
-    "away_score": (655,  0, 745,  72),
-    "home_score": (765,  0, 855,  72),
-    "quarter":    (1285, 20, 1340, 50),
-    "clock":      (1325, 20, 1445, 50),
-}
+# ROI fractions within SCOREBAR (kept simple/stable; adjust if you like)
+# (fx0, fy0, fx1, fy1) in 0..1 of the scorebar crop
+Z_TEAMS = (0.03, 0.08, 0.42, 0.92)
+Z_SCORE_L = (0.42, 0.12, 0.50, 0.90)
+Z_SCORE_R = (0.50, 0.12, 0.58, 0.90)
+Z_PERIOD  = (0.62, 0.12, 0.75, 0.90)
+Z_CLOCK   = (0.74, 0.12, 0.96, 0.90)
 
-# ---------- Regex / normalizers ----------
-_SCORE_RX   = re.compile(r"^\s*(\d{1,2})\s*[-:]\s*(\d{1,2})\s*$")
-_CLOCK_RX   = re.compile(r"^\s*(\d{1,2}):([0-5]\d)\s*$")
-_QTR_RX_QN  = re.compile(r"^(Q[1-4]|OT)$", re.I)
-_QTR_RX_MDN = re.compile(r"^(1ST|2ND|3RD|4TH|OT)$", re.I)
+# Regex helpers
+_SCORE_JOINED = re.compile(r"\b(\d{1,2})\s*[-:]\s*(\d{1,2})\b")
+_CLOCK_RX     = re.compile(r"^\s*(\d{1,2}):([0-5]\d)\s*$")
+_QTR_QN       = re.compile(r"^(Q[1-4]|OT)$", re.I)
+_QTR_MDN      = re.compile(r"^(1ST|2ND|3RD|4TH|OT)$", re.I)
 
-def _normalize_quarter(s: Optional[str]) -> Optional[str]:
-    if not s:
+def _normalize_quarter(txt: Optional[str]) -> Optional[str]:
+    if not txt:
         return None
-    x = s.strip().upper()
-    x = re.sub(r"1{2,}", "1", x)                 # "111st" -> "1st"
-    x = x.replace(" ", "").replace("0T", "OT")   # "0T" -> "OT"
-    x = x.replace("QI", "Q1").replace("QT", "Q1")
-    m = _QTR_RX_QN.match(x)
+    x = txt.strip().upper()
+    x = x.replace(" ", "").replace("0T", "OT").replace("QI", "Q1")
+    m = _QTR_QN.match(x)
     if m:
         return m.group(1).upper()
-    m2 = _QTR_RX_MDN.match(x)
-    if m2:
-        return {"1ST":"Q1","2ND":"Q2","3RD":"Q3","4TH":"Q4","OT":"OT"}[m2.group(1)]
+    m = _QTR_MDN.match(x)
+    if m:
+        return {"1ST": "Q1", "2ND": "Q2", "3RD": "Q3", "4TH": "Q4", "OT": "OT"}[m.group(1)]
     if re.fullmatch(r"[1-4]", x):
         return f"Q{x}"
     return None
 
-def _normalize_clock(s: Optional[str]) -> Optional[str]:
-    if not s:
+def _normalize_clock(txt: Optional[str]) -> Optional[str]:
+    if not txt:
         return None
-    x = s.strip()
-    if not re.search(r"\d", x):
-        return None
-    x = x.replace(";", ":").replace(" ", "")
+    x = txt.strip().replace(";", ":").replace(" ", "")
     m = _CLOCK_RX.match(x)
     if m:
         return f"{int(m.group(1))}:{m.group(2)}"
     return None
 
-def _digits1_2(s: Optional[str]) -> Optional[str]:
-    if not s:
-        return None
-    m = re.search(r"\d{1,2}", s)
-    return m.group(0) if m else None
-
-def _compose_score(away_s: Optional[str], home_s: Optional[str], joined: Optional[str]) -> Optional[str]:
-    a = _digits1_2(away_s)
-    h = _digits1_2(home_s)
-    if a is not None and h is not None:
-        return f"{int(a)}-{int(h)}"
-    if joined:
-        m = _SCORE_RX.match(joined.replace(":", "-"))
-        if m:
-            return f"{int(m.group(1))}-{int(m.group(2))}"
-    return None
-
-def _letters_only(s: str) -> str:
-    return re.sub(r"[^A-Z]", "", s.upper())
-
-
-# ---------- PaddleOCR singleton ----------
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from paddleocr import PaddleOCR
-
-_OCR_SINGLETON: Optional["paddleocr.PaddleOCR"] = None  # type: ignore
-_OCR_LOCK = Lock()
-
-def _get_ocr() -> Optional["paddleocr.PaddleOCR"]:  # type: ignore
-    """Thread-safe singleton initializer for PaddleOCR"""
-    global _OCR_SINGLETON
-    if PaddleOCR is None:
-        return None
-    with _OCR_LOCK:
-        if _OCR_SINGLETON is None:
-            # Initialize once; MPS on Apple Silicon is handled by paddlepaddle wheels
-            _OCR_SINGLETON = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)
-        return _OCR_SINGLETON
-
-# ---------- Frame helpers ----------
-def grab_frame_at_time(video_path: str, ts: float, out_path: str) -> Path:
-    """
-    Save a PNG for the frame at timestamp 'ts' (seconds).
-    Tries OpenCV first; falls back to ffmpeg -ss.
-    """
-    src = Path(video_path)
-    out = Path(out_path)
-    out.parent.mkdir(parents=True, exist_ok=True)
-
-    if cv2 is not None:
-        cap = cv2.VideoCapture(str(src))
-        if cap.isOpened():
-            cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, ts * 1000.0))
-            ok, frame = cap.read()
-            cap.release()
-            if ok and frame is not None:
-                frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                Image.fromarray(frame_rgb).save(out)
-                return out
-
-    cmd = f'ffmpeg -y -v error -ss {ts:.3f} -i {shlex.quote(str(src))} -frames:v 1 {shlex.quote(str(out))}'
-    subprocess.run(cmd, shell=True, check=False)
-    if out.exists():
-        return out
-
-    raise RuntimeError(f"Could not grab frame at t={ts:.3f}s. Install opencv-python or ffmpeg.")
-
-def _scale_box_to_frame(box: Tuple[int, int, int, int], w: int, h: int) -> Tuple[int, int, int, int]:
+def _scale_scorebar_box_to_frame(box: Tuple[int,int,int,int], w: int, h: int) -> Tuple[int,int,int,int]:
     lx, ty, rx, by = box
     sx = w / REF_FRAME_W
     sy = h / REF_FRAME_H
     return (int(lx * sx), int(ty * sy), int(rx * sx), int(by * sy))
 
-def crop_scorebar_from_frame(frame_path: str, out_path: str, box: Tuple[int, int, int, int] = SCOREBAR_BOX) -> Path:
-    """Crop the scoreboard bar from a full frame; auto-scales box if frame != 2047x1155."""
-    ip = Path(frame_path)
-    op = Path(out_path)
-    op.parent.mkdir(parents=True, exist_ok=True)
-    with Image.open(ip) as im:
+def _crop_frac(im: Image.Image, fx0: float, fy0: float, fx1: float, fy1: float) -> Image.Image:
+    w, h = im.size
+    x0, y0 = int(fx0 * w), int(fy0 * h)
+    x1, y1 = int(fx1 * w), int(fy1 * h)
+    return im.crop((x0, y0, x1, y1))
+
+def _grab_frame(video_path: str, ts: float, out_path: Path) -> Path:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = f'ffmpeg -y -v error -ss {ts:.3f} -i {shlex.quote(video_path)} -frames:v 1 {shlex.quote(str(out_path))}'
+    subprocess.run(cmd, shell=True, check=False)
+    if not out_path.exists():
+        raise RuntimeError(f"Could not grab frame at t={ts:.3f}s")
+    return out_path
+
+def _crop_scorebar(frame_png: Path, out_path: Path) -> Path:
+    with Image.open(frame_png) as im:
         w, h = im.size
-        if (w, h) != (REF_FRAME_W, REF_FRAME_H):
-            lx, ty, rx, by = _scale_box_to_frame(box, w, h)
-        else:
-            lx, ty, rx, by = box
-        crop = im.crop((lx, ty, rx, by))
-        crop.save(op)
-        return op
+        lx, ty, rx, by = _scale_scorebar_box_to_frame(SCOREBAR_BOX, w, h)
+        sb = im.crop((lx, ty, rx, by))
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        sb.save(out_path)
+    return out_path
 
+# Lazy OCR instance (heavy to init)
+_OCR: Optional[_PaddleOCRType] = None
 
-# ---------- Per-call ROI scaling & OCR ----------
-def _crop_px_from_ref(sb_img: Image.Image,
-                      box_px: Tuple[int, int, int, int],
-                      ref_size: Tuple[int, int]) -> Image.Image:
-    """Scale pixel ROI from per-call ref_size onto current scorebar image."""
-    ref_w, ref_h = ref_size
-    w, h = sb_img.size
-    sx = w / float(ref_w)
-    sy = h / float(ref_h)
-    x0, y0, x1, y1 = box_px
-    X0, Y0 = max(0, int(round(x0 * sx))), max(0, int(round(y0 * sy)))
-    X1, Y1 = min(w, int(round(x1 * sx))), min(h, int(round(y1 * sy)))
-    return sb_img.crop((X0, Y0, X1, Y1))
+def _get_ocr() -> Optional[_PaddleOCRType]:
+    global _OCR
+    if _OCR is None and PaddleOCR is not None:
+        _OCR = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)  # type: ignore[call-arg]
+    return _OCR
 
-def _ocr_text_from_pil(pil_img: Image.Image) -> str:
+def _ocr_image_text(pil_img: Image.Image) -> List[Tuple[str, float]]:
     """
-    Run PaddleOCR on a PIL image without touching the filesystem.
-    Paddle expects BGR ndarray; convert from RGB first.
+    Run OCR on a PIL image object (no temp file races).
+    Returns list of (text, confidence).
     """
     ocr = _get_ocr()
     if ocr is None:
-        return ""
-    rgb = np.array(pil_img.convert("RGB"))
-    bgr = rgb[:, :, ::-1]  # RGB -> BGR
-    res = ocr.ocr(bgr, cls=False)
-    if not res or not res[0]:
-        return ""
-    return " ".join((line[1][0] or "").strip() for line in res[0] if line and line[1])
+        return []
+    # PaddleOCR accepts ndarray path or file path; we’ll use ndarray via temp PNG in-memory.
+    # Convert PIL -> tmp path within run dir is avoided; feed ndarray directly.
+    import numpy as np  # local import to avoid global hard deps during import
+    arr = np.array(pil_img.convert("RGB"))
+    try:
+        res = ocr.ocr(arr, cls=False)
+    except Exception:
+        return []
+    out: List[Tuple[str, float]] = []
+    if isinstance(res, list) and res and isinstance(res[0], list):
+        for line in res[0]:
+            if not line or len(line) < 2: 
+                continue
+            txt = line[1][0]
+            conf = float(line[1][1] or 0.0)
+            if isinstance(txt, str) and txt.strip():
+                out.append((txt.strip(), conf))
+    return out
 
+def _join_text(lines: List[Tuple[str, float]]) -> str:
+    return " ".join(t for t, _ in lines)
 
-def _viz_px_rois(scorebar_pil: Image.Image, out_path: str, ref_size: Tuple[int, int]) -> None:
-    w, h = scorebar_pil.size
-    ref_w, ref_h = ref_size
-    sx = w / float(ref_w)
-    sy = h / float(ref_h)
-    vis = scorebar_pil.copy()
-    d = ImageDraw.Draw(vis)
-    colors = {
-        "away_team": "orange",
-        "home_team": "orange",
-        "away_score": "lime",
-        "home_score": "lime",
-        "quarter": "deepskyblue",
-        "clock": "deepskyblue",
-    }
-    for key, (x0, y0, x1, y1) in SB_ROIS_PX.items():
-        X0, Y0 = int(round(x0 * sx)), int(round(y0 * sy))
-        X1, Y1 = int(round(x1 * sx)), int(round(y1 * sy))
-        d.rectangle((X0, Y0, X1, Y1), outline=colors.get(key, "yellow"), width=3)
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    vis.save(out_path)
+def _parse_score(away_txt: str, home_txt: str, joined_txt: str) -> Optional[str]:
+    # Prefer separate digits first
+    def _first_int(s: str) -> Optional[int]:
+        m = re.search(r"\d{1,2}", s)
+        return int(m.group(0)) if m else None
+    a = _first_int(away_txt)
+    h = _first_int(home_txt)
+    if a is not None and h is not None:
+        return f"{a}-{h}"
+    # Fallback to joined “A-H”
+    m = _SCORE_JOINED.search(joined_txt.replace(":", "-"))
+    if m:
+        return f"{int(m.group(1))}-{int(m.group(2))}"
+    return None
 
+def _viz_rois(scorebar_png: Path, out_path: Path) -> None:
+    with Image.open(scorebar_png) as sb:
+        vis = sb.copy()
+        d = ImageDraw.Draw(vis)
+        def draw(box, color):
+            w, h = sb.size
+            fx0, fy0, fx1, fy1 = box
+            d.rectangle((int(fx0*w), int(fy0*h), int(fx1*w), int(fy1*h)), outline=color, width=3)
+        draw(Z_TEAMS,   "orange")
+        draw(Z_SCORE_L, "lime")
+        draw(Z_SCORE_R, "lime")
+        draw(Z_PERIOD,  "deepskyblue")
+        draw(Z_CLOCK,   "deepskyblue")
+        vis.save(out_path)
 
-# ---------- Main entry ----------
 def extract_scoreboard_from_video_paddle(
     video_path: str,
     *,
-    t: float = 0.10,          # start slightly after 0s
-    attempts: int = 3,        # quick voting
+    t: float = 0.10,
+    attempts: int = 3,
     viz: bool = False,
 ) -> Dict[str, Any]:
     """
-    Grab a few frames, crop your fixed scoreboard strip, OCR per-ROI via PaddleOCR in-memory,
-    and vote for stability. Returns:
-      {away_team, home_team, away_score, home_score, score, clock, quarter, used_stub}
+    Per-request isolated temp dir; OCR the bottom scorebar with PaddleOCR.
+    Returns dict: away_team, home_team, score, clock, quarter, used_stub
     """
-    # Early check: if PaddleOCR isn't present, bail with stub so the caller can fall back.
-    if _get_ocr() is None:
-        return {"used_stub": True}
+    # --- per-run folder ---
+    run_id = uuid.uuid4().hex[:10]
+    run_dir = TMP_ROOT / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
 
-    ts_list: List[float] = [max(0.0, t + k * 0.10) for k in range(max(1, attempts))]
+    keep_tmp = os.getenv("KEEP_TMP", "0") == "1"
+    try:
+        # Collect a few timestamps
+        times = [max(0.0, t + k*0.10) for k in range(max(1, attempts))]
+        best: Dict[str, Any] = {}
+        def completeness(d: Dict[str, Any]) -> int:
+            return sum(1 for k in ("away_team","home_team","score","clock","quarter") if d.get(k))
 
-    # Voting pools
-    away_teams: List[str] = []
-    home_teams: List[str] = []
-    away_scores: List[str] = []
-    home_scores: List[str] = []
-    clocks: List[str] = []
-    quarters: List[str] = []
+        for idx, ts in enumerate(times):
+            frame_png = run_dir / f"frame_t{ts:.2f}.png"
+            score_png = run_dir / f"scorebar_t{ts:.2f}.png"
+            _grab_frame(video_path, ts, frame_png)
+            _crop_scorebar(frame_png, score_png)
 
-    first_scorebar: Optional[Image.Image] = None
-    ref_size: Optional[Tuple[int, int]] = None
+            if viz and idx == 0:
+                _viz_rois(score_png, run_dir / f"scorebar_rois_t{ts:.2f}.png")
 
-    for idx, ts in enumerate(ts_list):
-        # 1) frame -> scorebar crop
-        frame_png = grab_frame_at_time(video_path, ts, out_path=f"data/tmp/video_frame_t{ts:.2f}.png")
-        scorebar_png = crop_scorebar_from_frame(str(frame_png), out_path=f"data/tmp/scorebar_t{ts:.2f}.png")
-        with Image.open(scorebar_png) as sb:
-            scorebar_pil = sb.convert("RGB")
+            # OCR per ROI
+            with Image.open(score_png) as sb:
+                teams_img = _crop_frac(sb, *Z_TEAMS)
+                l_img     = _crop_frac(sb, *Z_SCORE_L)
+                r_img     = _crop_frac(sb, *Z_SCORE_R)
+                per_img   = _crop_frac(sb, *Z_PERIOD)
+                clk_img   = _crop_frac(sb, *Z_CLOCK)
 
-        if first_scorebar is None:
-            first_scorebar = scorebar_pil
-            ref_size = first_scorebar.size
-            if viz:
-                _viz_px_rois(scorebar_pil, f"data/tmp/scorebar_viz_t{ts:.2f}.png", ref_size)
+                teams_txt = _join_text(_ocr_image_text(teams_img))
+                away_frag = _join_text(_ocr_image_text(l_img))
+                home_frag = _join_text(_ocr_image_text(r_img))
+                per_txt   = _join_text(_ocr_image_text(per_img))
+                clk_txt   = _join_text(_ocr_image_text(clk_img))
 
-        assert ref_size is not None
+            # Basic normalization
+            # Try to split teams into two short tokens if possible (left/right zones are digits only, so we trust Z_TEAMS for names)
+            away_team = None
+            home_team = None
+            if teams_txt:
+                toks = re.findall(r"[A-Z]{2,4}", teams_txt.upper())
+                if len(toks) >= 2:
+                    away_team, home_team = toks[0], toks[1]
+                elif len(toks) == 1:
+                    # best-effort single token
+                    away_team = toks[0]
 
-        # 2) crop all ROIs relative to per-call ref_size
-        a_team_img  = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["away_team"],  ref_size)
-        h_team_img  = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["home_team"],  ref_size)
-        a_score_img = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["away_score"], ref_size)
-        h_score_img = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["home_score"], ref_size)
-        qtr_img     = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["quarter"],    ref_size)
-        clk_img     = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["clock"],      ref_size)
+            score = _parse_score(away_frag, home_frag, f"{away_frag} {home_frag}")
+            quarter = _normalize_quarter(per_txt)
+            clock   = _normalize_clock(clk_txt)
 
-        # 3) OCR in-memory
-        a_team_txt = _letters_only(_ocr_text_from_pil(a_team_img))
-        h_team_txt = _letters_only(_ocr_text_from_pil(h_team_img))
-        a_score_txt = _ocr_text_from_pil(a_score_img)
-        h_score_txt = _ocr_text_from_pil(h_score_img)
-        qtr_txt = _normalize_quarter(_ocr_text_from_pil(qtr_img))
-        clk_txt = _normalize_clock(_ocr_text_from_pil(clk_img))
+            cur = {
+                "away_team": away_team,
+                "home_team": home_team,
+                "score": score,
+                "clock": clock,
+                "quarter": quarter,
+            }
 
-        # 4) normalize scores to digits (keep single/two-digit)
-        a_score_d = _digits1_2(a_score_txt)
-        h_score_d = _digits1_2(h_score_txt)
+            if completeness(cur) > completeness(best):
+                best = cur
+                if completeness(best) == 5:
+                    break
 
-        if a_team_txt:
-            away_teams.append(a_team_txt)
-        if h_team_txt:
-            home_teams.append(h_team_txt)
-        if a_score_d is not None:
-            away_scores.append(a_score_d)
-        if h_score_d is not None:
-            home_scores.append(h_score_d)
-        if qtr_txt:
-            quarters.append(qtr_txt)
-        if clk_txt:
-            clocks.append(clk_txt)
+        if not best:
+            return {"used_stub": True}
+        best["used_stub"] = False
+        # Drop where we wrote artifacts (useful for debugging)
+        if viz:
+            best["_debug_dir"] = str(run_dir)
+        return best
 
-    # Voting helpers
-    def _mode_str(vals: List[str]) -> Optional[str]:
-        vals = [v for v in vals if v]
-        return Counter(vals).most_common(1)[0][0] if vals else None
-
-    away_team = _mode_str(away_teams)
-    home_team = _mode_str(home_teams)
-    away_sc   = _mode_str(away_scores)
-    home_sc   = _mode_str(home_scores)
-    clock     = _mode_str(clocks)
-    quarter   = _mode_str(quarters)
-
-    score = _compose_score(away_sc, home_sc, None)
-
-    # Build result
-    out: Dict[str, Any] = {
-        "away_team": away_team,
-        "home_team": home_team,
-        "away_score": away_sc,
-        "home_score": home_sc,
-        "score": score,
-        "clock": clock,
-        "quarter": quarter,
-        "used_stub": False,
-    }
-
-    # If nothing meaningful was extracted, mark as stub so caller can decide fallback.
-    if not any([away_team, home_team, away_sc, home_sc, clock, quarter]):
-        return {"used_stub": True}
-
-    return out
-
-
-if __name__ == "__main__":
-    import sys, json
-    video = sys.argv[1] if len(sys.argv) > 1 else "Madden Clip.mp4"
-    flags = {a for a in sys.argv[2:] if a.startswith("--") and "=" not in a}
-    kvs = [a for a in sys.argv[2:] if a.startswith("--") and "=" in a]
-    viz = ("--viz" in flags)
-    t = 0.10
-    attempts = 3
-    for kv in kvs:
-        if kv.startswith("--t="):
-            try: t = float(kv.split("=", 1)[1])
-            except: pass
-        elif kv.startswith("--attempts="):
-            try: attempts = int(kv.split("=", 1)[1])
-            except: pass
-
-    data = extract_scoreboard_from_video_paddle(video, t=t, attempts=attempts, viz=viz)
-    print(json.dumps(data, indent=2))
+    finally:
+        # Clean up run folder unless explicitly asked to keep or viz requested
+        if not viz and not keep_tmp:
+            try:
+                shutil.rmtree(run_dir, ignore_errors=True)
+            except Exception:
+                pass

--- a/backend/services/ocr_paddle.py
+++ b/backend/services/ocr_paddle.py
@@ -1,0 +1,287 @@
+# backend/services/ocr_paddle.py
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional, Dict, Any, List, Tuple, TYPE_CHECKING
+import os, re, subprocess, shlex, time
+
+# ----- Optional dependency: PaddleOCR -----
+try:
+    from paddleocr import PaddleOCR  # type: ignore
+except Exception:
+    PaddleOCR = None  # type: ignore
+
+if TYPE_CHECKING:
+    from paddleocr import PaddleOCR as PaddleOCRType
+else:
+    PaddleOCRType = object
+
+# Pillow / drawing
+from PIL import Image, ImageDraw, ImageOps
+
+# ---------- Reference full-frame → scoreboard crop ----------
+# These are the same as your legacy code (bottom strip on 2047x1155 reference)
+REF_FRAME_W, REF_FRAME_H = 2047, 1155
+SCOREBAR_BOX = (0, 1080, 2047, 1155)  # (left, top, right, bottom) in reference space
+
+# ---------- Your pixel ROIs on the scoreboard crop (x0, y0, x1, y1) ----------
+# (Do NOT change unless you want to retune; these are your confirmed boxes)
+SB_ROIS_PX: Dict[str, Tuple[int,int,int,int]] = {
+    "away_team":  (500,  0,   600,  50),
+    "home_team":  (900,  0,  1000,  50),
+    "away_score": (655,  0,   745,  72),
+    "home_score": (765,  0,   855,  72),
+    "quarter":    (1285, 20, 1340,  50),
+    "clock":      (1325, 20, 1445,  50),
+}
+
+# ------- Regex helpers -------
+_SCORE_RX   = re.compile(r"^\s*(\d{1,2})\s*[-:]\s*(\d{1,2})\s*$")
+_CLOCK_RX   = re.compile(r"^\s*(\d{1,2}):([0-5]\d)\s*$")
+_QTR_RX_QN  = re.compile(r"^(Q[1-4]|OT)$", re.I)
+_QTR_RX_MDN = re.compile(r"^(1ST|2ND|3RD|4TH|OT)$", re.I)
+
+# ---------- Paddle singleton ----------
+_OCR_SINGLETON: Optional[PaddleOCRType] = None
+
+def _get_paddle_ocr() -> Optional[PaddleOCRType]:
+    global _OCR_SINGLETON
+    if _OCR_SINGLETON is not None:
+        return _OCR_SINGLETON
+    if PaddleOCR is None:
+        return None
+    # English, no angle classifier; quiet logs
+    _OCR_SINGLETON = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)
+    return _OCR_SINGLETON
+
+# ---------- FFmpeg frame grab + scoreboard crop ----------
+def _scale_box_to_frame(box: Tuple[int,int,int,int], w: int, h: int) -> Tuple[int,int,int,int]:
+    lx, ty, rx, by = box
+    sx = w / REF_FRAME_W
+    sy = h / REF_FRAME_H
+    return (int(lx * sx), int(ty * sy), int(rx * sx), int(by * sy))
+
+def _grab_frame(video_path: str, t: float, out_png: Path) -> Path:
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    cmd = f'ffmpeg -y -v error -ss {t:.3f} -i {shlex.quote(video_path)} -frames:v 1 {shlex.quote(str(out_png))}'
+    subprocess.run(cmd, shell=True, check=False)
+    if not out_png.exists():
+        raise RuntimeError(f"Failed to grab frame at t={t:.3f}s")
+    return out_png
+
+def _crop_scorebar(full_frame_png: Path, out_png: Path) -> Path:
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    with Image.open(full_frame_png) as im:
+        w, h = im.size
+        lx, ty, rx, by = _scale_box_to_frame(SCOREBAR_BOX, w, h)
+        crop = im.crop((lx, ty, rx, by))
+        crop.save(out_png)
+        return out_png
+
+# ---------- ROI helpers ----------
+_SB_REF_OVERRIDE: Optional[Tuple[int,int]] = None  # set by first crop we see
+
+def _prep_gray_bw(pil: Image.Image, thresh: int = 165, invert: bool = False) -> Image.Image:
+    g = pil.convert("L")
+    table = [0] * (thresh + 1) + [255] * (256 - (thresh + 1))
+    bw = g.point(table, mode="L")
+    if invert:
+        bw = ImageOps.invert(bw)
+    return bw
+
+def _crop_px_from_ref(sb_img: Image.Image, box_px: Tuple[int,int,int,int]) -> Image.Image:
+    """
+    Scale your pixel coords from the *auto-detected* reference (first crop size)
+    to the current crop size; lets you reuse the same boxes across different
+    scorebar resolutions.
+    """
+    global _SB_REF_OVERRIDE
+    w, h = sb_img.size
+    if _SB_REF_OVERRIDE is None:
+        _SB_REF_OVERRIDE = (w, h)
+    ref_w, ref_h = _SB_REF_OVERRIDE
+    sx = w / float(ref_w)
+    sy = h / float(ref_h)
+    x0, y0, x1, y1 = box_px
+    X0, Y0 = max(0, int(round(x0 * sx))), max(0, int(round(y0 * sy)))
+    X1, Y1 = min(w, int(round(x1 * sx))),  min(h, int(round(y1 * sy)))
+    return sb_img.crop((X0, Y0, X1, Y1))
+
+def _viz_rois(sb_img_path: Path, out_base: Path) -> None:
+    """
+    Save:
+      - <out_base>_zones.png : scorebar with colored ROI rectangles
+      - <out_base>_<key>_raw.png : raw crop per ROI
+      - <out_base>_<key>_bw.png  : binarized crop per ROI
+    """
+    with Image.open(sb_img_path) as sb:
+        # ensure ref set
+        _ = _crop_px_from_ref(sb, SB_ROIS_PX["away_team"])
+        w, h = sb.size
+        ref_w, ref_h = _SB_REF_OVERRIDE or (w, h)
+        sx = w / float(ref_w)
+        sy = h / float(ref_h)
+
+        vis = sb.copy()
+        d = ImageDraw.Draw(vis)
+        colors = {
+            "away_team": "orange",
+            "home_team": "orange",
+            "away_score":"lime",
+            "home_score":"lime",
+            "quarter":   "deepskyblue",
+            "clock":     "deepskyblue",
+        }
+        out_base.parent.mkdir(parents=True, exist_ok=True)
+
+        # draw rectangles
+        for key, (x0,y0,x1,y1) in SB_ROIS_PX.items():
+            X0, Y0 = int(round(x0*sx)), int(round(y0*sy))
+            X1, Y1 = int(round(x1*sx)), int(round(y1*sy))
+            d.rectangle((X0, Y0, X1, Y1), outline=colors.get(key,"yellow"), width=3)
+
+        vis.save(out_base.with_name(out_base.name + "_zones.png"))
+
+        # per-ROI crops
+        for key in SB_ROIS_PX.keys():
+            c = _crop_px_from_ref(sb, SB_ROIS_PX[key])
+            c.save(out_base.with_name(out_base.name + f"_{key}_raw.png"))
+            _prep_gray_bw(c).save(out_base.with_name(out_base.name + f"_{key}_bw.png"))
+
+# ---------- Small text normalizers ----------
+def _norm_quarter(s: Optional[str]) -> Optional[str]:
+    if not s: return None
+    x = s.strip().upper().replace(" ", "")
+    x = re.sub(r"1{2,}", "1", x)  # "111st" -> "1st"
+    x = x.replace("0T", "OT").replace("QI", "Q1").replace("QT", "Q1")
+    m = _QTR_RX_QN.match(x)
+    if m: return m.group(1).upper()
+    m2 = _QTR_RX_MDN.match(x)
+    if m2: return {"1ST":"Q1","2ND":"Q2","3RD":"Q3","4TH":"Q4","OT":"OT"}[m2.group(1)]
+    if re.fullmatch(r"[1-4]", x):
+        return f"Q{x}"
+    return None
+
+def _norm_clock(s: Optional[str]) -> Optional[str]:
+    if not s: return None
+    x = s.strip().replace(";", ":").replace(" ", "")
+    if not re.search(r"\d", x):
+        return None
+    m = _CLOCK_RX.match(x)
+    if m:
+        return f"{int(m.group(1))}:{m.group(2)}"
+    return None
+
+def _digits(s: Optional[str]) -> Optional[str]:
+    if not s: return None
+    m = re.search(r"\d{1,2}", s)
+    return m.group(0) if m else None
+
+# ---------- OCR routines ----------
+def _ocr_text(paddle: PaddleOCRType, pil: Image.Image) -> str:
+    # PaddleOCR expects file path or ndarray; we can save temp PNG in ramdisk dir
+    tmp = Path("data/tmp/ocr_patch.png")
+    tmp.parent.mkdir(parents=True, exist_ok=True)
+    pil.save(tmp)
+    res = paddle.ocr(str(tmp), cls=False)  # type: ignore
+    txts: List[str] = []
+    if res and isinstance(res, list) and res[0]:
+        for line in res[0]:
+            # line: [ [[x,y],...8], (text, conf) ]
+            txt = line[1][0]
+            if isinstance(txt, str) and txt.strip():
+                txts.append(txt.strip())
+    try:
+        tmp.unlink(missing_ok=True)
+    except Exception:
+        pass
+    return " ".join(txts)
+
+def _ocr_digits(paddle: PaddleOCRType, pil: Image.Image) -> Optional[str]:
+    raw = _ocr_text(paddle, pil)
+    clean = re.sub(r"[^0-9]", "", raw)
+    return clean or None
+
+def _ocr_letters(paddle: PaddleOCRType, pil: Image.Image) -> Optional[str]:
+    raw = _ocr_text(paddle, pil)
+    clean = re.sub(r"[^A-Za-z]", "", raw).upper()
+    return clean or None
+
+def _compose_score(away_s: Optional[str], home_s: Optional[str], joined: Optional[str]) -> Optional[str]:
+    if away_s is not None and home_s is not None and away_s != "" and home_s != "":
+        return f"{int(away_s)}-{int(home_s)}"
+    if joined:
+        m = _SCORE_RX.match(joined.replace(":", "-"))
+        if m:
+            return f"{int(m.group(1))}-{int(m.group(2))}"
+    return None
+
+# ---------- Public entry ----------
+def extract_scoreboard_from_video_paddle(
+    video_path: str,
+    *,
+    t: float = 0.10,
+    attempts: int = 3,
+    viz: bool = False,
+) -> Dict[str, Any]:
+    """
+    Grab N frames around t, crop the scoreboard, OCR fixed ROIs with PaddleOCR,
+    and return a normalized scoreboard dict. If viz=True, saves ROI overlays and crops
+    under data/tmp/.
+    """
+    paddle = _get_paddle_ocr()
+    if paddle is None:
+        # Dependency missing → tell caller to fall back or stub
+        return {"used_stub": True}
+
+    # reset ROI calibration per call
+    global _SB_REF_OVERRIDE
+    _SB_REF_OVERRIDE = None
+
+    times = [max(0.0, t + 0.10 * k) for k in range(max(1, attempts))]
+    best: Dict[str, Any] = {}
+    def completeness(d: Dict[str, Any]) -> int:
+        return sum(1 for k in ("away_team","home_team","score","clock","quarter") if d.get(k))
+
+    for idx, ts in enumerate(times):
+        frame_png = _grab_frame(video_path, ts, Path(f"data/tmp/paddle_frame_t{ts:.2f}.png"))
+        sb_png = _crop_scorebar(frame_png, Path(f"data/tmp/paddle_scorebar_t{ts:.2f}.png"))
+
+        if viz and idx == 0:
+            _viz_rois(sb_png, sb_png.with_name(f"paddle_scorebar_viz_t{ts:.2f}"))
+
+        with Image.open(sb_png) as sb_im:
+            away_team = _ocr_letters(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["away_team"]))
+            home_team = _ocr_letters(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["home_team"]))
+
+            away_sc = _ocr_digits(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["away_score"]))
+            home_sc = _ocr_digits(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["home_score"]))
+
+            quarter_raw = _ocr_text(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["quarter"]))
+            clock_raw   = _ocr_text(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["clock"]))
+
+            # joined score (rarely used, but try from whole scorebar if needed)
+            joined = None  # we keep ROIs tight; joined OCR is noisy on Madden bar
+
+        q_norm = _norm_quarter(quarter_raw)
+        c_norm = _norm_clock(clock_raw)
+        s_norm = _compose_score(away_sc, home_sc, joined)
+
+        cur = {
+            "away_team": away_team,
+            "home_team": home_team,
+            "score": s_norm,
+            "clock": c_norm,
+            "quarter": q_norm,
+        }
+
+        if completeness(cur) > completeness(best):
+            best = cur
+            if completeness(best) == 5:
+                break
+        # tiny pause helps when reading sequential frames from disk
+        time.sleep(0.01)
+
+    if not best:
+        return {"used_stub": True}
+    best["used_stub"] = False
+    return best

--- a/backend/services/ocr_paddle.py
+++ b/backend/services/ocr_paddle.py
@@ -1,287 +1,354 @@
 # backend/services/ocr_paddle.py
 from __future__ import annotations
-from pathlib import Path
-from typing import Optional, Dict, Any, List, Tuple, TYPE_CHECKING
-import os, re, subprocess, shlex, time
 
-# ----- Optional dependency: PaddleOCR -----
+import os
+import shlex
+import subprocess
+import time
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from collections import Counter
+from threading import Lock
+
+import numpy as np
+
+# Pillow
+from PIL import Image, ImageDraw
+
+# Optional OpenCV (faster frame grabs if available)
+try:
+    import cv2  # type: ignore
+except Exception:
+    cv2 = None  # fallback to ffmpeg
+
+# PaddleOCR (lazy init)
 try:
     from paddleocr import PaddleOCR  # type: ignore
-except Exception:
+except Exception as e:
     PaddleOCR = None  # type: ignore
 
-if TYPE_CHECKING:
-    from paddleocr import PaddleOCR as PaddleOCRType
-else:
-    PaddleOCRType = object
 
-# Pillow / drawing
-from PIL import Image, ImageDraw, ImageOps
-
-# ---------- Reference full-frame → scoreboard crop ----------
-# These are the same as your legacy code (bottom strip on 2047x1155 reference)
+# ---------- Reference full-frame -> scoreboard crop ----------
+# Reference full-frame: 2047x1155, scoreboard y=[1080,1155)
 REF_FRAME_W, REF_FRAME_H = 2047, 1155
 SCOREBAR_BOX = (0, 1080, 2047, 1155)  # (left, top, right, bottom) in reference space
 
-# ---------- Your pixel ROIs on the scoreboard crop (x0, y0, x1, y1) ----------
-# (Do NOT change unless you want to retune; these are your confirmed boxes)
-SB_ROIS_PX: Dict[str, Tuple[int,int,int,int]] = {
-    "away_team":  (500,  0,   600,  50),
-    "home_team":  (900,  0,  1000,  50),
-    "away_score": (655,  0,   745,  72),
-    "home_score": (765,  0,   855,  72),
-    "quarter":    (1285, 20, 1340,  50),
-    "clock":      (1325, 20, 1445,  50),
+# ---------- Your exact pixel ROIs on the scoreboard crop (x0, y0, x1, y1) ----------
+# (Keep these as you tuned them for Madden.)
+SB_ROIS_PX: Dict[str, Tuple[int, int, int, int]] = {
+    "away_team":  (500,  0, 600,  50),
+    "home_team":  (900,  0, 1000, 50),
+    "away_score": (655,  0, 745,  72),
+    "home_score": (765,  0, 855,  72),
+    "quarter":    (1285, 20, 1340, 50),
+    "clock":      (1325, 20, 1445, 50),
 }
 
-# ------- Regex helpers -------
+# ---------- Regex / normalizers ----------
 _SCORE_RX   = re.compile(r"^\s*(\d{1,2})\s*[-:]\s*(\d{1,2})\s*$")
 _CLOCK_RX   = re.compile(r"^\s*(\d{1,2}):([0-5]\d)\s*$")
 _QTR_RX_QN  = re.compile(r"^(Q[1-4]|OT)$", re.I)
 _QTR_RX_MDN = re.compile(r"^(1ST|2ND|3RD|4TH|OT)$", re.I)
 
-# ---------- Paddle singleton ----------
-_OCR_SINGLETON: Optional[PaddleOCRType] = None
-
-def _get_paddle_ocr() -> Optional[PaddleOCRType]:
-    global _OCR_SINGLETON
-    if _OCR_SINGLETON is not None:
-        return _OCR_SINGLETON
-    if PaddleOCR is None:
+def _normalize_quarter(s: Optional[str]) -> Optional[str]:
+    if not s:
         return None
-    # English, no angle classifier; quiet logs
-    _OCR_SINGLETON = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)
-    return _OCR_SINGLETON
-
-# ---------- FFmpeg frame grab + scoreboard crop ----------
-def _scale_box_to_frame(box: Tuple[int,int,int,int], w: int, h: int) -> Tuple[int,int,int,int]:
-    lx, ty, rx, by = box
-    sx = w / REF_FRAME_W
-    sy = h / REF_FRAME_H
-    return (int(lx * sx), int(ty * sy), int(rx * sx), int(by * sy))
-
-def _grab_frame(video_path: str, t: float, out_png: Path) -> Path:
-    out_png.parent.mkdir(parents=True, exist_ok=True)
-    cmd = f'ffmpeg -y -v error -ss {t:.3f} -i {shlex.quote(video_path)} -frames:v 1 {shlex.quote(str(out_png))}'
-    subprocess.run(cmd, shell=True, check=False)
-    if not out_png.exists():
-        raise RuntimeError(f"Failed to grab frame at t={t:.3f}s")
-    return out_png
-
-def _crop_scorebar(full_frame_png: Path, out_png: Path) -> Path:
-    out_png.parent.mkdir(parents=True, exist_ok=True)
-    with Image.open(full_frame_png) as im:
-        w, h = im.size
-        lx, ty, rx, by = _scale_box_to_frame(SCOREBAR_BOX, w, h)
-        crop = im.crop((lx, ty, rx, by))
-        crop.save(out_png)
-        return out_png
-
-# ---------- ROI helpers ----------
-_SB_REF_OVERRIDE: Optional[Tuple[int,int]] = None  # set by first crop we see
-
-def _prep_gray_bw(pil: Image.Image, thresh: int = 165, invert: bool = False) -> Image.Image:
-    g = pil.convert("L")
-    table = [0] * (thresh + 1) + [255] * (256 - (thresh + 1))
-    bw = g.point(table, mode="L")
-    if invert:
-        bw = ImageOps.invert(bw)
-    return bw
-
-def _crop_px_from_ref(sb_img: Image.Image, box_px: Tuple[int,int,int,int]) -> Image.Image:
-    """
-    Scale your pixel coords from the *auto-detected* reference (first crop size)
-    to the current crop size; lets you reuse the same boxes across different
-    scorebar resolutions.
-    """
-    global _SB_REF_OVERRIDE
-    w, h = sb_img.size
-    if _SB_REF_OVERRIDE is None:
-        _SB_REF_OVERRIDE = (w, h)
-    ref_w, ref_h = _SB_REF_OVERRIDE
-    sx = w / float(ref_w)
-    sy = h / float(ref_h)
-    x0, y0, x1, y1 = box_px
-    X0, Y0 = max(0, int(round(x0 * sx))), max(0, int(round(y0 * sy)))
-    X1, Y1 = min(w, int(round(x1 * sx))),  min(h, int(round(y1 * sy)))
-    return sb_img.crop((X0, Y0, X1, Y1))
-
-def _viz_rois(sb_img_path: Path, out_base: Path) -> None:
-    """
-    Save:
-      - <out_base>_zones.png : scorebar with colored ROI rectangles
-      - <out_base>_<key>_raw.png : raw crop per ROI
-      - <out_base>_<key>_bw.png  : binarized crop per ROI
-    """
-    with Image.open(sb_img_path) as sb:
-        # ensure ref set
-        _ = _crop_px_from_ref(sb, SB_ROIS_PX["away_team"])
-        w, h = sb.size
-        ref_w, ref_h = _SB_REF_OVERRIDE or (w, h)
-        sx = w / float(ref_w)
-        sy = h / float(ref_h)
-
-        vis = sb.copy()
-        d = ImageDraw.Draw(vis)
-        colors = {
-            "away_team": "orange",
-            "home_team": "orange",
-            "away_score":"lime",
-            "home_score":"lime",
-            "quarter":   "deepskyblue",
-            "clock":     "deepskyblue",
-        }
-        out_base.parent.mkdir(parents=True, exist_ok=True)
-
-        # draw rectangles
-        for key, (x0,y0,x1,y1) in SB_ROIS_PX.items():
-            X0, Y0 = int(round(x0*sx)), int(round(y0*sy))
-            X1, Y1 = int(round(x1*sx)), int(round(y1*sy))
-            d.rectangle((X0, Y0, X1, Y1), outline=colors.get(key,"yellow"), width=3)
-
-        vis.save(out_base.with_name(out_base.name + "_zones.png"))
-
-        # per-ROI crops
-        for key in SB_ROIS_PX.keys():
-            c = _crop_px_from_ref(sb, SB_ROIS_PX[key])
-            c.save(out_base.with_name(out_base.name + f"_{key}_raw.png"))
-            _prep_gray_bw(c).save(out_base.with_name(out_base.name + f"_{key}_bw.png"))
-
-# ---------- Small text normalizers ----------
-def _norm_quarter(s: Optional[str]) -> Optional[str]:
-    if not s: return None
-    x = s.strip().upper().replace(" ", "")
-    x = re.sub(r"1{2,}", "1", x)  # "111st" -> "1st"
-    x = x.replace("0T", "OT").replace("QI", "Q1").replace("QT", "Q1")
+    x = s.strip().upper()
+    x = re.sub(r"1{2,}", "1", x)                 # "111st" -> "1st"
+    x = x.replace(" ", "").replace("0T", "OT")   # "0T" -> "OT"
+    x = x.replace("QI", "Q1").replace("QT", "Q1")
     m = _QTR_RX_QN.match(x)
-    if m: return m.group(1).upper()
+    if m:
+        return m.group(1).upper()
     m2 = _QTR_RX_MDN.match(x)
-    if m2: return {"1ST":"Q1","2ND":"Q2","3RD":"Q3","4TH":"Q4","OT":"OT"}[m2.group(1)]
+    if m2:
+        return {"1ST":"Q1","2ND":"Q2","3RD":"Q3","4TH":"Q4","OT":"OT"}[m2.group(1)]
     if re.fullmatch(r"[1-4]", x):
         return f"Q{x}"
     return None
 
-def _norm_clock(s: Optional[str]) -> Optional[str]:
-    if not s: return None
-    x = s.strip().replace(";", ":").replace(" ", "")
+def _normalize_clock(s: Optional[str]) -> Optional[str]:
+    if not s:
+        return None
+    x = s.strip()
     if not re.search(r"\d", x):
         return None
+    x = x.replace(";", ":").replace(" ", "")
     m = _CLOCK_RX.match(x)
     if m:
         return f"{int(m.group(1))}:{m.group(2)}"
     return None
 
-def _digits(s: Optional[str]) -> Optional[str]:
-    if not s: return None
+def _digits1_2(s: Optional[str]) -> Optional[str]:
+    if not s:
+        return None
     m = re.search(r"\d{1,2}", s)
     return m.group(0) if m else None
 
-# ---------- OCR routines ----------
-def _ocr_text(paddle: PaddleOCRType, pil: Image.Image) -> str:
-    # PaddleOCR expects file path or ndarray; we can save temp PNG in ramdisk dir
-    tmp = Path("data/tmp/ocr_patch.png")
-    tmp.parent.mkdir(parents=True, exist_ok=True)
-    pil.save(tmp)
-    res = paddle.ocr(str(tmp), cls=False)  # type: ignore
-    txts: List[str] = []
-    if res and isinstance(res, list) and res[0]:
-        for line in res[0]:
-            # line: [ [[x,y],...8], (text, conf) ]
-            txt = line[1][0]
-            if isinstance(txt, str) and txt.strip():
-                txts.append(txt.strip())
-    try:
-        tmp.unlink(missing_ok=True)
-    except Exception:
-        pass
-    return " ".join(txts)
-
-def _ocr_digits(paddle: PaddleOCRType, pil: Image.Image) -> Optional[str]:
-    raw = _ocr_text(paddle, pil)
-    clean = re.sub(r"[^0-9]", "", raw)
-    return clean or None
-
-def _ocr_letters(paddle: PaddleOCRType, pil: Image.Image) -> Optional[str]:
-    raw = _ocr_text(paddle, pil)
-    clean = re.sub(r"[^A-Za-z]", "", raw).upper()
-    return clean or None
-
 def _compose_score(away_s: Optional[str], home_s: Optional[str], joined: Optional[str]) -> Optional[str]:
-    if away_s is not None and home_s is not None and away_s != "" and home_s != "":
-        return f"{int(away_s)}-{int(home_s)}"
+    a = _digits1_2(away_s)
+    h = _digits1_2(home_s)
+    if a is not None and h is not None:
+        return f"{int(a)}-{int(h)}"
     if joined:
         m = _SCORE_RX.match(joined.replace(":", "-"))
         if m:
             return f"{int(m.group(1))}-{int(m.group(2))}"
     return None
 
-# ---------- Public entry ----------
+def _letters_only(s: str) -> str:
+    return re.sub(r"[^A-Z]", "", s.upper())
+
+
+# ---------- PaddleOCR singleton ----------
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from paddleocr import PaddleOCR
+
+_OCR_SINGLETON: Optional["paddleocr.PaddleOCR"] = None  # type: ignore
+_OCR_LOCK = Lock()
+
+def _get_ocr() -> Optional["paddleocr.PaddleOCR"]:  # type: ignore
+    """Thread-safe singleton initializer for PaddleOCR"""
+    global _OCR_SINGLETON
+    if PaddleOCR is None:
+        return None
+    with _OCR_LOCK:
+        if _OCR_SINGLETON is None:
+            # Initialize once; MPS on Apple Silicon is handled by paddlepaddle wheels
+            _OCR_SINGLETON = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)
+        return _OCR_SINGLETON
+
+# ---------- Frame helpers ----------
+def grab_frame_at_time(video_path: str, ts: float, out_path: str) -> Path:
+    """
+    Save a PNG for the frame at timestamp 'ts' (seconds).
+    Tries OpenCV first; falls back to ffmpeg -ss.
+    """
+    src = Path(video_path)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if cv2 is not None:
+        cap = cv2.VideoCapture(str(src))
+        if cap.isOpened():
+            cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, ts * 1000.0))
+            ok, frame = cap.read()
+            cap.release()
+            if ok and frame is not None:
+                frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                Image.fromarray(frame_rgb).save(out)
+                return out
+
+    cmd = f'ffmpeg -y -v error -ss {ts:.3f} -i {shlex.quote(str(src))} -frames:v 1 {shlex.quote(str(out))}'
+    subprocess.run(cmd, shell=True, check=False)
+    if out.exists():
+        return out
+
+    raise RuntimeError(f"Could not grab frame at t={ts:.3f}s. Install opencv-python or ffmpeg.")
+
+def _scale_box_to_frame(box: Tuple[int, int, int, int], w: int, h: int) -> Tuple[int, int, int, int]:
+    lx, ty, rx, by = box
+    sx = w / REF_FRAME_W
+    sy = h / REF_FRAME_H
+    return (int(lx * sx), int(ty * sy), int(rx * sx), int(by * sy))
+
+def crop_scorebar_from_frame(frame_path: str, out_path: str, box: Tuple[int, int, int, int] = SCOREBAR_BOX) -> Path:
+    """Crop the scoreboard bar from a full frame; auto-scales box if frame != 2047x1155."""
+    ip = Path(frame_path)
+    op = Path(out_path)
+    op.parent.mkdir(parents=True, exist_ok=True)
+    with Image.open(ip) as im:
+        w, h = im.size
+        if (w, h) != (REF_FRAME_W, REF_FRAME_H):
+            lx, ty, rx, by = _scale_box_to_frame(box, w, h)
+        else:
+            lx, ty, rx, by = box
+        crop = im.crop((lx, ty, rx, by))
+        crop.save(op)
+        return op
+
+
+# ---------- Per-call ROI scaling & OCR ----------
+def _crop_px_from_ref(sb_img: Image.Image,
+                      box_px: Tuple[int, int, int, int],
+                      ref_size: Tuple[int, int]) -> Image.Image:
+    """Scale pixel ROI from per-call ref_size onto current scorebar image."""
+    ref_w, ref_h = ref_size
+    w, h = sb_img.size
+    sx = w / float(ref_w)
+    sy = h / float(ref_h)
+    x0, y0, x1, y1 = box_px
+    X0, Y0 = max(0, int(round(x0 * sx))), max(0, int(round(y0 * sy)))
+    X1, Y1 = min(w, int(round(x1 * sx))), min(h, int(round(y1 * sy)))
+    return sb_img.crop((X0, Y0, X1, Y1))
+
+def _ocr_text_from_pil(pil_img: Image.Image) -> str:
+    """
+    Run PaddleOCR on a PIL image without touching the filesystem.
+    Paddle expects BGR ndarray; convert from RGB first.
+    """
+    ocr = _get_ocr()
+    if ocr is None:
+        return ""
+    rgb = np.array(pil_img.convert("RGB"))
+    bgr = rgb[:, :, ::-1]  # RGB -> BGR
+    res = ocr.ocr(bgr, cls=False)
+    if not res or not res[0]:
+        return ""
+    return " ".join((line[1][0] or "").strip() for line in res[0] if line and line[1])
+
+
+def _viz_px_rois(scorebar_pil: Image.Image, out_path: str, ref_size: Tuple[int, int]) -> None:
+    w, h = scorebar_pil.size
+    ref_w, ref_h = ref_size
+    sx = w / float(ref_w)
+    sy = h / float(ref_h)
+    vis = scorebar_pil.copy()
+    d = ImageDraw.Draw(vis)
+    colors = {
+        "away_team": "orange",
+        "home_team": "orange",
+        "away_score": "lime",
+        "home_score": "lime",
+        "quarter": "deepskyblue",
+        "clock": "deepskyblue",
+    }
+    for key, (x0, y0, x1, y1) in SB_ROIS_PX.items():
+        X0, Y0 = int(round(x0 * sx)), int(round(y0 * sy))
+        X1, Y1 = int(round(x1 * sx)), int(round(y1 * sy))
+        d.rectangle((X0, Y0, X1, Y1), outline=colors.get(key, "yellow"), width=3)
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    vis.save(out_path)
+
+
+# ---------- Main entry ----------
 def extract_scoreboard_from_video_paddle(
     video_path: str,
     *,
-    t: float = 0.10,
-    attempts: int = 3,
+    t: float = 0.10,          # start slightly after 0s
+    attempts: int = 3,        # quick voting
     viz: bool = False,
 ) -> Dict[str, Any]:
     """
-    Grab N frames around t, crop the scoreboard, OCR fixed ROIs with PaddleOCR,
-    and return a normalized scoreboard dict. If viz=True, saves ROI overlays and crops
-    under data/tmp/.
+    Grab a few frames, crop your fixed scoreboard strip, OCR per-ROI via PaddleOCR in-memory,
+    and vote for stability. Returns:
+      {away_team, home_team, away_score, home_score, score, clock, quarter, used_stub}
     """
-    paddle = _get_paddle_ocr()
-    if paddle is None:
-        # Dependency missing → tell caller to fall back or stub
+    # Early check: if PaddleOCR isn't present, bail with stub so the caller can fall back.
+    if _get_ocr() is None:
         return {"used_stub": True}
 
-    # reset ROI calibration per call
-    global _SB_REF_OVERRIDE
-    _SB_REF_OVERRIDE = None
+    ts_list: List[float] = [max(0.0, t + k * 0.10) for k in range(max(1, attempts))]
 
-    times = [max(0.0, t + 0.10 * k) for k in range(max(1, attempts))]
-    best: Dict[str, Any] = {}
-    def completeness(d: Dict[str, Any]) -> int:
-        return sum(1 for k in ("away_team","home_team","score","clock","quarter") if d.get(k))
+    # Voting pools
+    away_teams: List[str] = []
+    home_teams: List[str] = []
+    away_scores: List[str] = []
+    home_scores: List[str] = []
+    clocks: List[str] = []
+    quarters: List[str] = []
 
-    for idx, ts in enumerate(times):
-        frame_png = _grab_frame(video_path, ts, Path(f"data/tmp/paddle_frame_t{ts:.2f}.png"))
-        sb_png = _crop_scorebar(frame_png, Path(f"data/tmp/paddle_scorebar_t{ts:.2f}.png"))
+    first_scorebar: Optional[Image.Image] = None
+    ref_size: Optional[Tuple[int, int]] = None
 
-        if viz and idx == 0:
-            _viz_rois(sb_png, sb_png.with_name(f"paddle_scorebar_viz_t{ts:.2f}"))
+    for idx, ts in enumerate(ts_list):
+        # 1) frame -> scorebar crop
+        frame_png = grab_frame_at_time(video_path, ts, out_path=f"data/tmp/video_frame_t{ts:.2f}.png")
+        scorebar_png = crop_scorebar_from_frame(str(frame_png), out_path=f"data/tmp/scorebar_t{ts:.2f}.png")
+        with Image.open(scorebar_png) as sb:
+            scorebar_pil = sb.convert("RGB")
 
-        with Image.open(sb_png) as sb_im:
-            away_team = _ocr_letters(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["away_team"]))
-            home_team = _ocr_letters(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["home_team"]))
+        if first_scorebar is None:
+            first_scorebar = scorebar_pil
+            ref_size = first_scorebar.size
+            if viz:
+                _viz_px_rois(scorebar_pil, f"data/tmp/scorebar_viz_t{ts:.2f}.png", ref_size)
 
-            away_sc = _ocr_digits(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["away_score"]))
-            home_sc = _ocr_digits(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["home_score"]))
+        assert ref_size is not None
 
-            quarter_raw = _ocr_text(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["quarter"]))
-            clock_raw   = _ocr_text(paddle, _crop_px_from_ref(sb_im, SB_ROIS_PX["clock"]))
+        # 2) crop all ROIs relative to per-call ref_size
+        a_team_img  = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["away_team"],  ref_size)
+        h_team_img  = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["home_team"],  ref_size)
+        a_score_img = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["away_score"], ref_size)
+        h_score_img = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["home_score"], ref_size)
+        qtr_img     = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["quarter"],    ref_size)
+        clk_img     = _crop_px_from_ref(scorebar_pil, SB_ROIS_PX["clock"],      ref_size)
 
-            # joined score (rarely used, but try from whole scorebar if needed)
-            joined = None  # we keep ROIs tight; joined OCR is noisy on Madden bar
+        # 3) OCR in-memory
+        a_team_txt = _letters_only(_ocr_text_from_pil(a_team_img))
+        h_team_txt = _letters_only(_ocr_text_from_pil(h_team_img))
+        a_score_txt = _ocr_text_from_pil(a_score_img)
+        h_score_txt = _ocr_text_from_pil(h_score_img)
+        qtr_txt = _normalize_quarter(_ocr_text_from_pil(qtr_img))
+        clk_txt = _normalize_clock(_ocr_text_from_pil(clk_img))
 
-        q_norm = _norm_quarter(quarter_raw)
-        c_norm = _norm_clock(clock_raw)
-        s_norm = _compose_score(away_sc, home_sc, joined)
+        # 4) normalize scores to digits (keep single/two-digit)
+        a_score_d = _digits1_2(a_score_txt)
+        h_score_d = _digits1_2(h_score_txt)
 
-        cur = {
-            "away_team": away_team,
-            "home_team": home_team,
-            "score": s_norm,
-            "clock": c_norm,
-            "quarter": q_norm,
-        }
+        if a_team_txt:
+            away_teams.append(a_team_txt)
+        if h_team_txt:
+            home_teams.append(h_team_txt)
+        if a_score_d is not None:
+            away_scores.append(a_score_d)
+        if h_score_d is not None:
+            home_scores.append(h_score_d)
+        if qtr_txt:
+            quarters.append(qtr_txt)
+        if clk_txt:
+            clocks.append(clk_txt)
 
-        if completeness(cur) > completeness(best):
-            best = cur
-            if completeness(best) == 5:
-                break
-        # tiny pause helps when reading sequential frames from disk
-        time.sleep(0.01)
+    # Voting helpers
+    def _mode_str(vals: List[str]) -> Optional[str]:
+        vals = [v for v in vals if v]
+        return Counter(vals).most_common(1)[0][0] if vals else None
 
-    if not best:
+    away_team = _mode_str(away_teams)
+    home_team = _mode_str(home_teams)
+    away_sc   = _mode_str(away_scores)
+    home_sc   = _mode_str(home_scores)
+    clock     = _mode_str(clocks)
+    quarter   = _mode_str(quarters)
+
+    score = _compose_score(away_sc, home_sc, None)
+
+    # Build result
+    out: Dict[str, Any] = {
+        "away_team": away_team,
+        "home_team": home_team,
+        "away_score": away_sc,
+        "home_score": home_sc,
+        "score": score,
+        "clock": clock,
+        "quarter": quarter,
+        "used_stub": False,
+    }
+
+    # If nothing meaningful was extracted, mark as stub so caller can decide fallback.
+    if not any([away_team, home_team, away_sc, home_sc, clock, quarter]):
         return {"used_stub": True}
-    best["used_stub"] = False
-    return best
+
+    return out
+
+
+if __name__ == "__main__":
+    import sys, json
+    video = sys.argv[1] if len(sys.argv) > 1 else "Madden Clip.mp4"
+    flags = {a for a in sys.argv[2:] if a.startswith("--") and "=" not in a}
+    kvs = [a for a in sys.argv[2:] if a.startswith("--") and "=" in a]
+    viz = ("--viz" in flags)
+    t = 0.10
+    attempts = 3
+    for kv in kvs:
+        if kv.startswith("--t="):
+            try: t = float(kv.split("=", 1)[1])
+            except: pass
+        elif kv.startswith("--attempts="):
+            try: attempts = int(kv.split("=", 1)[1])
+            except: pass
+
+    data = extract_scoreboard_from_video_paddle(video, t=t, attempts=attempts, viz=viz)
+    print(json.dumps(data, indent=2))

--- a/backend/services/ocr_paddle.py
+++ b/backend/services/ocr_paddle.py
@@ -1,168 +1,229 @@
 # backend/services/ocr_paddle.py
 from __future__ import annotations
+
+from typing import Dict, Any, Optional, Tuple, List
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
-import os, uuid, shlex, subprocess, re, shutil
-from typing import Any, Optional, TYPE_CHECKING
+import uuid, subprocess, shlex
+import re
+
+import numpy as np
+from paddleocr import PaddleOCR
 
 try:
-    from paddleocr import PaddleOCR  # runtime import
+    import cv2  # type: ignore
 except Exception:
-    PaddleOCR = None  # type: ignore[assignment]
+    cv2 = None
 
-if TYPE_CHECKING:
-    # static type name only visible to the type checker
-    from paddleocr import PaddleOCR as _PaddleOCRType
-else:
-    _PaddleOCRType = Any  # at runtime we don't care
+from PIL import Image, ImageDraw, ImageOps
 
-from PIL import Image, ImageDraw
 
-# ---------- Config ----------
-DATA_DIR = Path(os.getenv("DATA_DIR", "data"))
-TMP_ROOT = DATA_DIR / "tmp" / "runs"
-TMP_ROOT.mkdir(parents=True, exist_ok=True)
-
-# Reference full frame dims & scoreboard strip at bottom (like your old pipeline)
+# ------------------------
+# Constants
+# ------------------------
 REF_FRAME_W, REF_FRAME_H = 2047, 1155
-SCOREBAR_BOX = (0, 1080, 2047, 1155)  # left, top, right, bottom in reference space
+SCOREBAR_BOX = (0, 1080, 2047, 1155)  # bottom banner in reference frame
 
-# ROI fractions within SCOREBAR (kept simple/stable; adjust if you like)
-# (fx0, fy0, fx1, fy1) in 0..1 of the scorebar crop
-Z_TEAMS = (0.03, 0.08, 0.42, 0.92)
-Z_SCORE_L = (0.42, 0.12, 0.50, 0.90)
-Z_SCORE_R = (0.50, 0.12, 0.58, 0.90)
-Z_PERIOD  = (0.62, 0.12, 0.75, 0.90)
-Z_CLOCK   = (0.74, 0.12, 0.96, 0.90)
+# Your fixed pixel ROIs on the scoreboard crop (do not change)
+SB_ROIS_PX: Dict[str, Tuple[int, int, int, int]] = {
+    "away_team":  (500,  0,  600,  50),
+    "home_team":  (900,  0, 1000,  50),
+    "away_score": (655,  0,  745,  72),
+    "home_score": (765,  0,  855,  72),
+    "quarter":    (1280, 20, 1330, 50),   # narrow crop: first digit only
+    "clock":      (1325, 20, 1445, 50),
+}
 
-# Regex helpers
-_SCORE_JOINED = re.compile(r"\b(\d{1,2})\s*[-:]\s*(\d{1,2})\b")
-_CLOCK_RX     = re.compile(r"^\s*(\d{1,2}):([0-5]\d)\s*$")
-_QTR_QN       = re.compile(r"^(Q[1-4]|OT)$", re.I)
-_QTR_MDN      = re.compile(r"^(1ST|2ND|3RD|4TH|OT)$", re.I)
 
-def _normalize_quarter(txt: Optional[str]) -> Optional[str]:
-    if not txt:
-        return None
-    x = txt.strip().upper()
-    x = x.replace(" ", "").replace("0T", "OT").replace("QI", "Q1")
-    m = _QTR_QN.match(x)
-    if m:
-        return m.group(1).upper()
-    m = _QTR_MDN.match(x)
-    if m:
-        return {"1ST": "Q1", "2ND": "Q2", "3RD": "Q3", "4TH": "Q4", "OT": "OT"}[m.group(1)]
-    if re.fullmatch(r"[1-4]", x):
-        return f"Q{x}"
-    return None
+# ------------------------
+# Utilities
+# ------------------------
+def _run_ffmpeg_grab(src: Path, ts: float, out_png: Path) -> bool:
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    cmd = f'ffmpeg -y -v error -ss {ts:.3f} -i {shlex.quote(str(src))} -frames:v 1 {shlex.quote(str(out_png))}'
+    subprocess.run(cmd, shell=True, check=False)
+    return out_png.exists()
 
-def _normalize_clock(txt: Optional[str]) -> Optional[str]:
-    if not txt:
-        return None
-    x = txt.strip().replace(";", ":").replace(" ", "")
-    m = _CLOCK_RX.match(x)
-    if m:
-        return f"{int(m.group(1))}:{m.group(2)}"
-    return None
+def _grab_frame(video_path: str, ts: float, out_png: Path) -> Path:
+    src = Path(video_path)
+    if cv2 is not None:
+        cap = cv2.VideoCapture(str(src))
+        if cap.isOpened():
+            cap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, ts * 1000.0))
+            ok, frame = cap.read()
+            cap.release()
+            if ok and frame is not None:
+                rgb = frame[:, :, ::-1]  # BGR->RGB
+                Image.fromarray(rgb).save(out_png)
+                return out_png
+    if _run_ffmpeg_grab(src, ts, out_png):
+        return out_png
+    raise RuntimeError(f"Could not grab frame at t={ts:.3f}s")
 
-def _scale_scorebar_box_to_frame(box: Tuple[int,int,int,int], w: int, h: int) -> Tuple[int,int,int,int]:
+def _scale_box_to_frame(box: Tuple[int, int, int, int], w: int, h: int) -> Tuple[int, int, int, int]:
     lx, ty, rx, by = box
     sx = w / REF_FRAME_W
     sy = h / REF_FRAME_H
     return (int(lx * sx), int(ty * sy), int(rx * sx), int(by * sy))
 
-def _crop_frac(im: Image.Image, fx0: float, fy0: float, fx1: float, fy1: float) -> Image.Image:
-    w, h = im.size
-    x0, y0 = int(fx0 * w), int(fy0 * h)
-    x1, y1 = int(fx1 * w), int(fy1 * h)
-    return im.crop((x0, y0, x1, y1))
-
-def _grab_frame(video_path: str, ts: float, out_path: Path) -> Path:
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    cmd = f'ffmpeg -y -v error -ss {ts:.3f} -i {shlex.quote(video_path)} -frames:v 1 {shlex.quote(str(out_path))}'
-    subprocess.run(cmd, shell=True, check=False)
-    if not out_path.exists():
-        raise RuntimeError(f"Could not grab frame at t={ts:.3f}s")
-    return out_path
-
-def _crop_scorebar(frame_png: Path, out_path: Path) -> Path:
+def _crop_scorebar(frame_png: Path, out_png: Path) -> Tuple[Path, Tuple[int, int]]:
     with Image.open(frame_png) as im:
         w, h = im.size
-        lx, ty, rx, by = _scale_scorebar_box_to_frame(SCOREBAR_BOX, w, h)
-        sb = im.crop((lx, ty, rx, by))
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        sb.save(out_path)
-    return out_path
+        lx, ty, rx, by = _scale_box_to_frame(SCOREBAR_BOX, w, h)
+        crop = im.crop((lx, ty, rx, by))
+        out_png.parent.mkdir(parents=True, exist_ok=True)
+        crop.save(out_png)
+        return out_png, crop.size
 
-# Lazy OCR instance (heavy to init)
-_OCR: Optional[_PaddleOCRType] = None
+def _crop_px_from_ref(sb_img: Image.Image, box_px: Tuple[int, int, int, int], ref_size: Tuple[int, int]) -> Image.Image:
+    w, h = sb_img.size
+    ref_w, ref_h = ref_size
+    sx = w / float(ref_w)
+    sy = h / float(ref_h)
+    x0, y0, x1, y1 = box_px
+    X0, Y0 = max(0, int(round(x0 * sx))), max(0, int(round(y0 * sy)))
+    X1, Y1 = min(w, int(round(x1 * sx))), min(h, int(round(y1 * sy)))
+    return sb_img.crop((X0, Y0, X1, Y1))
 
-def _get_ocr() -> Optional[_PaddleOCRType]:
-    global _OCR
-    if _OCR is None and PaddleOCR is not None:
-        _OCR = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)  # type: ignore[call-arg]
-    return _OCR
+def _prep_gray_bw(pil: Image.Image, thresh: int = 160, invert: bool = False) -> Image.Image:
+    g = pil.convert("L")
+    table = [0] * (thresh + 1) + [255] * (256 - (thresh + 1))
+    bw = g.point(table, mode="L")
+    if invert:
+        bw = ImageOps.invert(bw)
+    return bw
 
-def _ocr_image_text(pil_img: Image.Image) -> List[Tuple[str, float]]:
-    """
-    Run OCR on a PIL image object (no temp file races).
-    Returns list of (text, confidence).
-    """
-    ocr = _get_ocr()
-    if ocr is None:
-        return []
-    # PaddleOCR accepts ndarray path or file path; we’ll use ndarray via temp PNG in-memory.
-    # Convert PIL -> tmp path within run dir is avoided; feed ndarray directly.
-    import numpy as np  # local import to avoid global hard deps during import
-    arr = np.array(pil_img.convert("RGB"))
-    try:
-        res = ocr.ocr(arr, cls=False)
-    except Exception:
-        return []
-    out: List[Tuple[str, float]] = []
-    if isinstance(res, list) and res and isinstance(res[0], list):
-        for line in res[0]:
-            if not line or len(line) < 2: 
-                continue
-            txt = line[1][0]
-            conf = float(line[1][1] or 0.0)
-            if isinstance(txt, str) and txt.strip():
-                out.append((txt.strip(), conf))
-    return out
 
-def _join_text(lines: List[Tuple[str, float]]) -> str:
-    return " ".join(t for t, _ in lines)
+# ------------------------
+# Visualization
+# ------------------------
+def _draw_frame_scorebar_outline(frame_png: Path, out_png: Path) -> None:
+    with Image.open(frame_png) as im:
+        w, h = im.size
+        lx, ty, rx, by = _scale_box_to_frame(SCOREBAR_BOX, w, h)
+        vis = im.copy()
+        d = ImageDraw.Draw(vis)
+        d.rectangle((lx, ty, rx, by), outline="lime", width=4)
+        out_png.parent.mkdir(parents=True, exist_ok=True)
+        vis.save(out_png)
 
-def _parse_score(away_txt: str, home_txt: str, joined_txt: str) -> Optional[str]:
-    # Prefer separate digits first
-    def _first_int(s: str) -> Optional[int]:
-        m = re.search(r"\d{1,2}", s)
-        return int(m.group(0)) if m else None
-    a = _first_int(away_txt)
-    h = _first_int(home_txt)
-    if a is not None and h is not None:
-        return f"{a}-{h}"
-    # Fallback to joined “A-H”
-    m = _SCORE_JOINED.search(joined_txt.replace(":", "-"))
-    if m:
-        return f"{int(m.group(1))}-{int(m.group(2))}"
-    return None
-
-def _viz_rois(scorebar_png: Path, out_path: Path) -> None:
+def _viz_rois_on_scorebar(scorebar_png: Path, ref_size: Tuple[int, int], out_png: Path) -> None:
     with Image.open(scorebar_png) as sb:
+        w, h = sb.size
+        sx = w / float(ref_size[0])
+        sy = h / float(ref_size[1])
+
         vis = sb.copy()
         d = ImageDraw.Draw(vis)
-        def draw(box, color):
-            w, h = sb.size
-            fx0, fy0, fx1, fy1 = box
-            d.rectangle((int(fx0*w), int(fy0*h), int(fx1*w), int(fy1*h)), outline=color, width=3)
-        draw(Z_TEAMS,   "orange")
-        draw(Z_SCORE_L, "lime")
-        draw(Z_SCORE_R, "lime")
-        draw(Z_PERIOD,  "deepskyblue")
-        draw(Z_CLOCK,   "deepskyblue")
-        vis.save(out_path)
+        colors = {
+            "away_team":  "orange",
+            "home_team":  "orange",
+            "away_score": "lime",
+            "home_score": "lime",
+            "quarter":    "deepskyblue",
+            "clock":      "deepskyblue",
+        }
+        for key, (x0, y0, x1, y1) in SB_ROIS_PX.items():
+            X0, Y0 = int(round(x0 * sx)), int(round(y0 * sy))
+            X1, Y1 = int(round(x1 * sx)), int(round(y1 * sy))
+            d.rectangle((X0, Y0, X1, Y1), outline=colors.get(key, "yellow"), width=3)
+            d.text((X0 + 4, max(0, Y0 - 14)), key, fill=colors.get(key, "yellow"))
+        out_png.parent.mkdir(parents=True, exist_ok=True)
+        vis.save(out_png)
 
+
+# ------------------------
+# OCR helpers
+# ------------------------
+def _ocr_init() -> PaddleOCR:
+    return PaddleOCR(use_angle_cls=False, lang='en', show_log=False)
+
+def _ocr_text(ocr: PaddleOCR, pil_img: Image.Image) -> str:
+    try:
+        arr = np.array(pil_img.convert("RGB"))
+        res = ocr.ocr(arr, cls=False)
+    except Exception:
+        return ""
+    if not res or not isinstance(res, list) or not res[0]:
+        return ""
+    lines = res[0]
+    try:
+        best = max(lines, key=lambda ln: (ln[1][1] if isinstance(ln, list) and len(ln) > 1 else 0.0))
+        return (best[1][0] or "").strip()
+    except Exception:
+        return ""
+
+def _ocr_quarter_digit(ocr: PaddleOCR, pil_img: Image.Image) -> Optional[str]:
+    """
+    Read a single quarter digit (1..4) from a tight crop.
+    Tries a few binarization thresholds and inverted/normal modes; returns first valid.
+    Returns 'OT' if that appears explicitly.
+    """
+    for thresh in (145, 165, 185):
+        for inv in (False, True):
+            bw = _prep_gray_bw(pil_img, thresh=thresh, invert=inv)
+            txt = _ocr_text(ocr, bw) or ""
+            if "OT" in txt.upper():
+                return "OT"
+            txt = txt.replace("I", "1").replace("|", "1").replace("l", "1")
+            m = re.search(r"[1-4]", txt)
+            if m:
+                return m.group(0)
+    return None
+
+def _ordinal_from_digit(d: Optional[str]) -> Optional[str]:
+    if not d:
+        return None
+    d = d.strip()
+    if d == "1": return "1st"
+    if d == "2": return "2nd"
+    if d == "3": return "3rd"
+    if d == "4": return "4th"
+    if d.upper() == "OT": return "OT"
+    return None
+
+
+# ------------------------
+# Normalization + voting
+# ------------------------
+_CLOCK_RX = re.compile(r"^\s*(\d{1,2}):([0-5]\d)\s*$", re.I)
+
+def _norm_team(s: str) -> Optional[str]:
+    s = (s or "").strip()
+    if not s:
+        return None
+    return re.sub(r"[^A-Z]", "", s.upper()) or None
+
+def _digits2(s: str) -> Optional[int]:
+    m = re.search(r"\d{1,2}", (s or ""))
+    return int(m.group(0)) if m else None
+
+def _norm_clock(s: str) -> Optional[str]:
+    if not s:
+        return None
+    x = s.strip().replace(";", ":").replace(" ", "")
+    m = _CLOCK_RX.match(x)
+    if m:
+        return f"{int(m.group(1))}:{m.group(2)}"
+    return None
+
+def _mode_str(values: List[Optional[str]]) -> Optional[str]:
+    vals = [v for v in values if v]
+    if not vals:
+        return None
+    from collections import Counter
+    return Counter(vals).most_common(1)[0][0]
+
+def _mode_int(values: List[Optional[int]]) -> Optional[int]:
+    nums = [v for v in values if isinstance(v, int)]
+    if not nums:
+        return None
+    from collections import Counter
+    return Counter(nums).most_common(1)[0][0]
+
+
+# ------------------------
+# Public API with aggregation across frames
+# ------------------------
 def extract_scoreboard_from_video_paddle(
     video_path: str,
     *,
@@ -171,86 +232,98 @@ def extract_scoreboard_from_video_paddle(
     viz: bool = False,
 ) -> Dict[str, Any]:
     """
-    Per-request isolated temp dir; OCR the bottom scorebar with PaddleOCR.
-    Returns dict: away_team, home_team, score, clock, quarter, used_stub
+    Sample several frames; OCR each ROI; aggregate across frames:
+      - team names: mode of normalized strings
+      - scores: mode of per-side integers
+      - clock: mode of normalized strings
+      - quarter: read first digit/OT and map to ordinal (1st/2nd/3rd/4th/OT)
     """
-    # --- per-run folder ---
-    run_id = uuid.uuid4().hex[:10]
-    run_dir = TMP_ROOT / run_id
+    run_id = f"ocr_{uuid.uuid4().hex[:8]}"
+    run_dir = Path("data/tmp/ocr") / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
 
-    keep_tmp = os.getenv("KEEP_TMP", "0") == "1"
-    try:
-        # Collect a few timestamps
-        times = [max(0.0, t + k*0.10) for k in range(max(1, attempts))]
-        best: Dict[str, Any] = {}
-        def completeness(d: Dict[str, Any]) -> int:
-            return sum(1 for k in ("away_team","home_team","score","clock","quarter") if d.get(k))
+    ts_list: List[float] = [max(0.0, t + 0.10 * k) for k in range(max(1, attempts))]
+    ocr = _ocr_init()
 
-        for idx, ts in enumerate(times):
-            frame_png = run_dir / f"frame_t{ts:.2f}.png"
-            score_png = run_dir / f"scorebar_t{ts:.2f}.png"
-            _grab_frame(video_path, ts, frame_png)
-            _crop_scorebar(frame_png, score_png)
+    ref_size: Optional[Tuple[int, int]] = None
 
-            if viz and idx == 0:
-                _viz_rois(score_png, run_dir / f"scorebar_rois_t{ts:.2f}.png")
+    # Collect across frames
+    away_team_reads: List[Optional[str]] = []
+    home_team_reads: List[Optional[str]] = []
+    away_score_reads: List[Optional[int]] = []
+    home_score_reads: List[Optional[int]] = []
+    clock_reads: List[Optional[str]] = []
+    quarter_reads: List[Optional[str]] = []
 
-            # OCR per ROI
-            with Image.open(score_png) as sb:
-                teams_img = _crop_frac(sb, *Z_TEAMS)
-                l_img     = _crop_frac(sb, *Z_SCORE_L)
-                r_img     = _crop_frac(sb, *Z_SCORE_R)
-                per_img   = _crop_frac(sb, *Z_PERIOD)
-                clk_img   = _crop_frac(sb, *Z_CLOCK)
+    for i, ts in enumerate(ts_list):
+        frame_png = run_dir / f"frame_t{ts:.2f}.png"
+        score_png = run_dir / f"scorebar_t{ts:.2f}.png"
 
-                teams_txt = _join_text(_ocr_image_text(teams_img))
-                away_frag = _join_text(_ocr_image_text(l_img))
-                home_frag = _join_text(_ocr_image_text(r_img))
-                per_txt   = _join_text(_ocr_image_text(per_img))
-                clk_txt   = _join_text(_ocr_image_text(clk_img))
+        _grab_frame(video_path, ts, frame_png)
+        score_png, (sbw, sbh) = _crop_scorebar(frame_png, score_png)
+        if ref_size is None:
+            ref_size = (sbw, sbh)
 
-            # Basic normalization
-            # Try to split teams into two short tokens if possible (left/right zones are digits only, so we trust Z_TEAMS for names)
-            away_team = None
-            home_team = None
-            if teams_txt:
-                toks = re.findall(r"[A-Z]{2,4}", teams_txt.upper())
-                if len(toks) >= 2:
-                    away_team, home_team = toks[0], toks[1]
-                elif len(toks) == 1:
-                    # best-effort single token
-                    away_team = toks[0]
+        if viz and i == 0:
+            _draw_frame_scorebar_outline(frame_png, run_dir / f"frame_with_scorebar_t{ts:.2f}.png")
+            _viz_rois_on_scorebar(score_png, ref_size, run_dir / f"scorebar_rois_t{ts:.2f}.png")
 
-            score = _parse_score(away_frag, home_frag, f"{away_frag} {home_frag}")
-            quarter = _normalize_quarter(per_txt)
-            clock   = _normalize_clock(clk_txt)
+        with Image.open(score_png) as sb:
+            def grab_txt(key: str) -> str:
+                crop = _crop_px_from_ref(sb, SB_ROIS_PX[key], ref_size)  # type: ignore[arg-type]
+                crop_bw = _prep_gray_bw(crop, thresh=160, invert=False)
+                return _ocr_text(ocr, crop_bw)
 
-            cur = {
-                "away_team": away_team,
-                "home_team": home_team,
-                "score": score,
-                "clock": clock,
-                "quarter": quarter,
-            }
+            # teams & scores via general OCR
+            a_team_raw = grab_txt("away_team")
+            h_team_raw = grab_txt("home_team")
+            a_sc_raw   = grab_txt("away_score")
+            h_sc_raw   = grab_txt("home_score")
+            c_raw      = grab_txt("clock")
 
-            if completeness(cur) > completeness(best):
-                best = cur
-                if completeness(best) == 5:
-                    break
+            # quarter: read a single digit (or OT) from the tight crop, then map to ordinal
+            q_crop = _crop_px_from_ref(sb, SB_ROIS_PX["quarter"], ref_size)
+            q_digit_or_ot = _ocr_quarter_digit(ocr, q_crop)
+            q_ordinal = _ordinal_from_digit(q_digit_or_ot)
 
-        if not best:
-            return {"used_stub": True}
-        best["used_stub"] = False
-        # Drop where we wrote artifacts (useful for debugging)
-        if viz:
-            best["_debug_dir"] = str(run_dir)
-        return best
+        away_team_reads.append(_norm_team(a_team_raw))
+        home_team_reads.append(_norm_team(h_team_raw))
+        away_score_reads.append(_digits2(a_sc_raw))
+        home_score_reads.append(_digits2(h_sc_raw))
+        clock_reads.append(_norm_clock(c_raw))
+        quarter_reads.append(q_ordinal)
 
-    finally:
-        # Clean up run folder unless explicitly asked to keep or viz requested
-        if not viz and not keep_tmp:
-            try:
-                shutil.rmtree(run_dir, ignore_errors=True)
-            except Exception:
-                pass
+    # Aggregate
+    away_team = _mode_str(away_team_reads)
+    home_team = _mode_str(home_team_reads)
+    a_mode = _mode_int(away_score_reads)
+    h_mode = _mode_int(home_score_reads)
+    clk = _mode_str(clock_reads)
+    qtr = _mode_str(quarter_reads)
+
+    result: Dict[str, Any] = {
+        "away_team": away_team,
+        "home_team": home_team,
+        "score": (f"{a_mode}-{h_mode}" if (a_mode is not None and h_mode is not None) else None),
+        "clock": clk,
+        "quarter": qtr,  # "1st" / "2nd" / "3rd" / "4th" / "OT"
+        "used_stub": False,
+    }
+
+    # If we didn’t get anything at all, return stub
+    if not any((away_team, home_team, a_mode is not None, h_mode is not None, clk, qtr)):
+        return {"used_stub": True}
+
+    if viz:
+        result["_viz_dir"] = str(run_dir)
+
+    return result
+
+
+if __name__ == "__main__":
+    import sys, json
+    video = sys.argv[1] if len(sys.argv) > 1 else "Madden Clip.mp4"
+    flags = set(a for a in sys.argv[2:] if a.startswith("--"))
+    viz = ("--viz" in flags)
+    data = extract_scoreboard_from_video_paddle(video, viz=viz)
+    print(json.dumps(data, indent=2))

--- a/backend/services/tone_profiles.py
+++ b/backend/services/tone_profiles.py
@@ -81,8 +81,9 @@ def build_llm_prompt(context: dict, transcript: str | None = None) -> str:
         f"{sys}\n"
         f"Sport: {sport}. Tone: {tone}. POV: {pov}. Target length: {length_hint}.\n"
         f"Bias guideline: {bias_rules}\n"
-        f"If team names are known, mention them naturally. Avoid profanity.\n\n"
+        f"If team names are known, mention them naturally. These are NFL Teams, going by at most three letter abbrieviation.\n\n"
         f"CONTEXT: {context}\n\n"
         f"TRANSCRIPT: {snippet}\n\n"
         f"Commentary:"
+        f"Be sure to explicitly mention all parameters in your response. Do not improvise."
     )

--- a/backend/services/voices.py
+++ b/backend/services/voices.py
@@ -1,0 +1,33 @@
+# backend/services/voices.py
+from __future__ import annotations
+from typing import Any, Dict, List
+
+# ✅ Your verified 6 voices (unchanged)
+VOICE_CATALOG: List[Dict[str, Any]] = [
+    {"id": "tc_673eb45cdc1073aef51e6b90", "name": "Dean",    "gender": "male",   "emotions": ["tonedown", "normal", "toneup"]},
+    {"id": "tc_6412c42d733f60ab8ad369a9", "name": "Caitlyn", "gender": "female", "emotions": ["normal"]},
+    {"id": "tc_6837b58f80ceeb17115bb771", "name": "Walter",  "gender": "male",   "emotions": ["normal"]},
+    {"id": "tc_684a5a7ba2ce934624b59c6e", "name": "Nia",     "gender": "female", "emotions": ["normal", "tonedown"]},
+    {"id": "tc_623145940c2c1ff30c30f3a9", "name": "Matthew", "gender": "male",   "emotions": ["normal", "shout"]},
+    {"id": "tc_630494521f5003bebbfdafef", "name": "Rachel",  "gender": "female", "emotions": ["normal", "toneup", "happy"]},
+]
+
+# ✅ Preferred voice per (tone, gender)
+VOICE_BY_TONE_GENDER = {
+    "neutral": {"male": "tc_673eb45cdc1073aef51e6b90", "female": "tc_6412c42d733f60ab8ad369a9"},  # Dean / Caitlyn
+    "radio":   {"male": "tc_6837b58f80ceeb17115bb771", "female": "tc_684a5a7ba2ce934624b59c6e"},  # Walter / Nia
+    "hype":    {"male": "tc_623145940c2c1ff30c30f3a9", "female": "tc_630494521f5003bebbfdafef"},  # Matthew / Rachel
+}
+
+# ✅ Emotion preference per tone (for previews & fallback)
+PREFERRED_BY_TONE = {
+    "neutral": ["normal"],
+    "radio":   ["tonedown", "normal", "tonemid"],
+    "hype":    ["shout", "toneup", "happy", "normal"],
+}
+
+def pick_emotion_for_tone(tone: str, supported: list[str]) -> str:
+    for e in PREFERRED_BY_TONE.get(tone, ["normal"]):
+        if e in supported:
+            return e
+    return "normal"


### PR DESCRIPTION
Title: feat|fix|chore(scope): feat(paddleocr): integrate PaddleOCR for faster scoreboard parsing and improve frontend voice labeling

## Summary
- Replaced previous OCR pipeline with PaddleOCR (PP-OCRv4) for more accurate and faster scoreboard text extraction.
- Added new backend module ocr_paddle.py with ROI visualization and crop logic.
- Updated pipeline_api.py to call PaddleOCR and generate better commentary context.
- Refined tone_profiles.py prompt generation to include clearer OCR context values.
- Updated Commentator.jsx to display each voice’s tone/gender mapping for easier user selection.
- Cleaned and modernized requirements.txt with PaddleOCR dependencies and notes for Apple Silicon.
- Expanded .gitignore to exclude PaddleOCR cache and model directories.

## Testing
- [x] Ran backend: uvicorn backend.main:app --reload
- [x] Verified /pipeline/commentary-from-video and /pipeline/run-commentary-from-video both work with PaddleOCR extraction.
- [x] Confirmed OCR bounding boxes and printed LLM prompt for debugging.
- [x] Frontend npm run dev — verified voice preview cards now show “mapped for: hype/male”, etc.
- [x] Verified commentary output reflects extracted score, teams, and clock context.

## Next Steps
- [ ] Fine-tune ROI zones for consistent multi-digit score accuracy.
- [ ] Add async PaddleOCR inference option for concurrent uploads.
- [ ] Expand testing to different broadcast layouts (college vs NFL).
